### PR TITLE
docs: rewrite competition materials with CoreIntent/trading angle

### DIFF
--- a/AWARDS_TRACKER.md
+++ b/AWARDS_TRACKER.md
@@ -1,8 +1,8 @@
 # AWARDS TRACKER — Zynthio 2026
 
-![Status](https://img.shields.io/badge/status-active-brightgreen) ![Updated](https://img.shields.io/badge/updated-2026--04--16-blue) ![Year](https://img.shields.io/badge/year-2026-purple)
+![Status](https://img.shields.io/badge/status-active-brightgreen) ![Updated](https://img.shields.io/badge/updated-2026--04--16-blue) ![Year](https://img.shields.io/badge/year-2026-purple) ![Tracked](https://img.shields.io/badge/competitions-22-orange)
 
-> Tracking relevant competitions, awards, grants, and accelerators for Zynthio across AI, fintech, music technology, and startup categories.
+> Tracking relevant competitions, awards, grants, and accelerators for Zynthio across AI, fintech, music technology, and startup categories worldwide.
 
 ---
 
@@ -15,31 +15,37 @@ Before entering any competition, confirm:
 - [ ] Check eligibility: entity type, jurisdiction, stage, team size
 - [ ] Tailor the ask to what the specific competition offers
 - [ ] Attach financial projections if required ([FINANCIAL_MODEL.md](FINANCIAL_MODEL.md))
-- [ ] Check word/slide/video limits — adapt [COMPETITION_PORTFOLIO.md](COMPETITION_PORTFOLIO.md) accordingly
+- [ ] Check word/slide/video limits — adapt materials accordingly
+- [ ] Prepare competition-specific angle (AI, fintech, music, or startup — see notes below)
 
 ---
 
 ## Dashboard — Application Status
 
-| Competition | Category | Status | Deadline | Priority |
-|------------|----------|--------|----------|----------|
-| Callaghan Innovation R&D Grant | AI / R&D | Not started | Rolling | **HIGH** |
-| Creative HQ Startup Programme | Startup | Not started | TBC (check website) | **HIGH** |
-| Lightning Lab | SaaS / Deep tech | Not started | TBC (check website) | **HIGH** |
-| Startmate Accelerator (AU) | SaaS / Consumer | Not started | TBC (check website) | **HIGH** |
-| SXSW Sydney Startup Competition | Music / Tech | Not started | TBC (typically mid-year) | **HIGH** |
-| MIDEM Accelerator | Music industry | Not started | TBC (check website) | **HIGH** |
-| Music Ally LAUNCH | Music tech | Not started | TBC (check website) | **HIGH** |
-| Edmund Hillary Fellowship | Global impact | Not started | TBC (check website) | MEDIUM |
-| NZ Music Commission | Music industry | Not started | Rolling | MEDIUM |
-| Creative Australia Grants | Arts / Music | Not started | TBC | MEDIUM |
-| Product Hunt Hackathon | Product / AI | Not started | TBC | MEDIUM |
-| ITU AI for Good | AI impact | Not started | TBC | MEDIUM |
-| Techweek NZ | Tech / Startup | Not started | TBC (May–June 2026) | MEDIUM |
-| NZ Hi-Tech Awards | Tech | Not started | TBC (typically H1) | MEDIUM |
-| AWS Startup Programme | Cloud / AI | Not started | Rolling | LOW |
-| Google for Startups | Cloud / AI | Not started | Rolling | LOW |
-| Anthropic Partner / Builder | AI | Not started | Rolling | LOW |
+| # | Competition | Category | Region | Status | Deadline | Priority |
+|---|------------|----------|--------|--------|----------|----------|
+| 1 | Callaghan Innovation R&D Grant | AI / R&D | NZ | Not started | Rolling | **HIGH** |
+| 2 | Creative HQ Startup Programme | Startup | NZ | Not started | TBC | **HIGH** |
+| 3 | Lightning Lab | SaaS / Deep tech | NZ | Not started | TBC | **HIGH** |
+| 4 | Startmate Accelerator | SaaS / Consumer | AU | Not started | TBC | **HIGH** |
+| 5 | SXSW Sydney Startup Competition | Music / Tech | AU | Not started | TBC (mid-year) | **HIGH** |
+| 6 | MIDEM Accelerator | Music industry | INT | Not started | TBC | **HIGH** |
+| 7 | Music Ally LAUNCH | Music tech | INT | Not started | TBC | **HIGH** |
+| 8 | Antler Residency | Early-stage | AU/INT | Not started | Rolling | **HIGH** |
+| 9 | Techstars Music Accelerator | Music / Tech | INT | Not started | TBC | **HIGH** |
+| 10 | Edmund Hillary Fellowship | Global impact | NZ | Not started | TBC | MEDIUM |
+| 11 | NZ Music Commission | Music industry | NZ | Not started | Rolling | MEDIUM |
+| 12 | Creative Australia Grants | Arts / Music | AU | Not started | TBC | MEDIUM |
+| 13 | Product Hunt Launch | Product / AI | INT | Not started | When SongPal MVP ready | MEDIUM |
+| 14 | ITU AI for Good | AI impact | INT | Not started | TBC | MEDIUM |
+| 15 | Techweek NZ | Tech / Startup | NZ | Not started | May–June 2026 | MEDIUM |
+| 16 | NZ Hi-Tech Awards | Tech | NZ | Not started | TBC (H1) | MEDIUM |
+| 17 | NZTA (NZ Tech Alliance) Awards | Tech | NZ | Not started | TBC | MEDIUM |
+| 18 | AWS Startup Programme | Cloud / AI | INT | Not started | Rolling | LOW |
+| 19 | Google for Startups | Cloud / AI | INT | Not started | Rolling | LOW |
+| 20 | Anthropic Partner / Builder | AI | INT | Not started | Rolling | LOW |
+| 21 | Microsoft for Startups | Cloud / AI | INT | Not started | Rolling | LOW |
+| 22 | Y Combinator | Startup | INT | Not started | TBC (biannual) | STRETCH |
 
 ---
 
@@ -55,8 +61,8 @@ Before entering any competition, confirm:
 | What they offer | R&D co-funding (typically 40% of eligible R&D costs) |
 | Eligibility | NZ-incorporated company performing R&D in NZ |
 | Deadline | Rolling applications |
-| Zynthio angle | CoreeyAI AI orchestration, SongPal platform development, gTrade algorithmic trading R&D |
-| Action | Incorporate ZYNTHIO LIMITED first. Then apply. |
+| Zynthio angle | CoreeyAI multi-model orchestration R&D, SongPal Next.js platform development, gTrade algorithmic trading research |
+| Action | Incorporate ZYNTHIO LIMITED first. Then apply immediately. |
 | URL | [callaghaninnovation.govt.nz](https://www.callaghaninnovation.govt.nz) |
 | Status | **Not started** — requires incorporation |
 
@@ -69,8 +75,8 @@ Before entering any competition, confirm:
 | Fit | **HIGH** — strong creative-tech mandate; Zynthio's music + AI stack is a natural fit |
 | What they offer | Accelerator programme, mentorship, workspace, investor introductions |
 | Eligibility | Early-stage NZ-connected startups |
-| Deadline | Check website — typically cohort-based with application rounds |
-| Zynthio angle | SongPal as flagship product, sovereign creative stack narrative |
+| Deadline | Check website — typically cohort-based |
+| Zynthio angle | SongPal as flagship, sovereign creative stack narrative, multi-model AI |
 | URL | [creativehq.co.nz](https://www.creativehq.co.nz) |
 | Status | **Not started** |
 
@@ -80,11 +86,11 @@ Before entering any competition, confirm:
 |-------|--------|
 | Organiser | Lightning Lab / Callaghan Innovation |
 | Category | Deep tech, SaaS |
-| Fit | **HIGH** — SongPal SaaS angle; NZ accelerator with strong tech focus |
+| Fit | **HIGH** — SongPal SaaS model; NZ accelerator with strong tech mandate |
 | What they offer | Accelerator programme, seed investment, mentorship |
 | Eligibility | NZ-based or NZ-connected tech startups |
 | Deadline | Check website — cohort applications |
-| Zynthio angle | SongPal SaaS model, CoreeyAI B2B API, multi-model AI architecture |
+| Zynthio angle | SongPal SaaS, CoreeyAI B2B API, multi-model architecture, Next.js stack |
 | URL | [lightninglab.co.nz](https://www.lightninglab.co.nz) |
 | Status | **Not started** |
 
@@ -98,7 +104,7 @@ Before entering any competition, confirm:
 | What they offer | Grants, industry connections, export support |
 | Eligibility | NZ music artists and music businesses |
 | Deadline | Rolling / programme-specific |
-| Zynthio angle | DJ Zynrose as NZ artist using AI production tools; MOSOKO as NZ music education platform |
+| Zynthio angle | DJ Zynrose as NZ artist using AI production; MOSOKO as NZ music education platform |
 | URL | [nzmusic.org.nz](https://www.nzmusic.org.nz) |
 | Status | **Not started** |
 
@@ -108,11 +114,11 @@ Before entering any competition, confirm:
 |-------|--------|
 | Organiser | EHF |
 | Category | Global impact entrepreneurs |
-| Fit | MEDIUM — founder narrative (sovereign creative stack for global independent artists) |
+| Fit | MEDIUM — founder narrative (sovereign infrastructure for global independents) |
 | What they offer | Fellowship, NZ Global Impact Visa, community, mentorship |
 | Eligibility | Entrepreneurs with global impact potential; NZ connection |
-| Deadline | Check website — rolling/cohort |
-| Zynthio angle | Sovereign creative infrastructure for independent artists worldwide; NZ-based company with global ambition |
+| Deadline | Rolling/cohort |
+| Zynthio angle | Sovereign creative infrastructure for independent artists and traders worldwide |
 | URL | [ehf.org](https://www.ehf.org) |
 | Status | **Not started** |
 
@@ -126,7 +132,7 @@ Before entering any competition, confirm:
 | What they offer | Visibility, pitch competition, networking |
 | Eligibility | NZ tech companies |
 | Deadline | Typically May–June 2026 |
-| Zynthio angle | AI music production + sovereign architecture |
+| Zynthio angle | Multi-model AI orchestration + sovereign infrastructure |
 | Status | **Not started** |
 
 ### NZ Hi-Tech Awards
@@ -138,8 +144,8 @@ Before entering any competition, confirm:
 | Fit | MEDIUM — early-stage / emerging company category |
 | What they offer | Recognition, media coverage, investor visibility |
 | Eligibility | NZ tech companies |
-| Deadline | Typically H1 — check website |
-| Zynthio angle | Most innovative emerging tech company; AI + music intersection |
+| Deadline | Typically H1 |
+| Zynthio angle | Most innovative emerging tech; AI + music + trading intersection |
 | Status | **Not started** |
 
 ---
@@ -155,8 +161,8 @@ Before entering any competition, confirm:
 | Fit | **HIGH** — music-tech startup competition; SongPal + DJ Zynrose angle is strong |
 | What they offer | Showcase, industry exposure, investor access, media coverage |
 | Eligibility | Startups with music/tech/creative focus |
-| Deadline | Typically mid-year — check website |
-| Zynthio angle | SongPal AI music production, DJ Zynrose as performing proof of concept, sovereign creator stack |
+| Deadline | Typically mid-year |
+| Zynthio angle | SongPal AI music production, DJ Zynrose as performing proof of concept, competition model |
 | URL | [sxswsydney.com](https://www.sxswsydney.com) |
 | Status | **Not started** |
 
@@ -166,25 +172,39 @@ Before entering any competition, confirm:
 |-------|--------|
 | Organiser | Startmate |
 | Category | SaaS, consumer tech |
-| Fit | **HIGH** — AU/NZ accelerator; strong founder-market fit, SaaS model |
+| Fit | **HIGH** — AU/NZ accelerator; strong founder-market fit |
 | What they offer | Seed investment (~AUD $120K), mentorship, network |
-| Eligibility | Early-stage startups, AU/NZ founders welcome |
-| Deadline | Cohort-based — check website |
-| Zynthio angle | SongPal SaaS, CoreeyAI API licensing, multi-brand architecture |
+| Eligibility | Early-stage startups, AU/NZ founders |
+| Deadline | Cohort-based |
+| Zynthio angle | SongPal SaaS, CoreeyAI API, multi-model orchestration, gTrade competition model |
 | URL | [startmate.com](https://www.startmate.com) |
+| Status | **Not started** |
+
+### Antler Residency (AU/NZ)
+
+| Field | Detail |
+|-------|--------|
+| Organiser | Antler |
+| Category | Early-stage venture / AI |
+| Fit | **HIGH** — AI-focused, strong in AU/NZ; solo founders accepted |
+| What they offer | Pre-seed investment, co-founder matching (optional), mentorship |
+| Eligibility | Early-stage builders, global |
+| Deadline | Rolling cohorts |
+| Zynthio angle | Multi-model AI orchestration, sovereign architecture, self-funding model |
+| URL | [antler.co](https://www.antler.co) |
 | Status | **Not started** |
 
 ### Creative Australia Grants
 
 | Field | Detail |
 |-------|--------|
-| Organiser | Creative Australia (formerly Australia Council for the Arts) |
+| Organiser | Creative Australia |
 | Category | Arts, music, creative industries |
 | Fit | MEDIUM — MOSOKO education + DJ Zynrose artist angle |
 | What they offer | Project grants for arts and creative activity |
-| Eligibility | Australian citizens and permanent residents (Corey qualifies as AU citizen) |
+| Eligibility | Australian citizens (Corey qualifies) |
 | Deadline | Multiple rounds per year |
-| Zynthio angle | MOSOKO as cross-Tasman music education initiative; DJ Zynrose as AU/NZ artist using AI |
+| Zynthio angle | MOSOKO as cross-Tasman music education; DJ Zynrose as AU/NZ artist using AI |
 | URL | [creative.gov.au](https://www.creative.gov.au) |
 | Status | **Not started** |
 
@@ -201,8 +221,8 @@ Before entering any competition, confirm:
 | Fit | **HIGH** — leading music-tech startup competition globally |
 | What they offer | Showcase at MIDEM, industry introductions, investor access, media |
 | Eligibility | Music technology startups worldwide |
-| Deadline | Check website — typically early in year |
-| Zynthio angle | SongPal as AI music production platform; full creator stack differentiator |
+| Deadline | Typically early in year |
+| Zynthio angle | SongPal as AI music production platform; full sovereign creator stack |
 | URL | [midem.com](https://www.midem.com) |
 | Status | **Not started** |
 
@@ -212,26 +232,39 @@ Before entering any competition, confirm:
 |-------|--------|
 | Organiser | Music Ally |
 | Category | Music technology showcase |
-| Fit | **HIGH** — leading music-tech industry event with startup showcase |
+| Fit | **HIGH** — leading music-tech industry event |
 | What they offer | Showcase, pitch competition, press coverage, industry network |
 | Eligibility | Music tech startups |
 | Deadline | Check website |
-| Zynthio angle | SongPal AI production, DJ Zynrose proof of concept, sovereign stack |
+| Zynthio angle | SongPal AI production, DJ Zynrose proof of concept, open architecture |
 | URL | [musically.com](https://www.musically.com) |
 | Status | **Not started** |
 
-### Product Hunt Global Hackathon
+### Techstars Music Accelerator
+
+| Field | Detail |
+|-------|--------|
+| Organiser | Techstars |
+| Category | Music technology |
+| Fit | **HIGH** — dedicated music-tech accelerator with strong industry network |
+| What they offer | $120K investment, mentorship, demo day, industry connections |
+| Eligibility | Music tech startups globally |
+| Deadline | Check website — cohort-based |
+| Zynthio angle | SongPal + CoreeyAI + DJ Zynrose; multi-model AI for music; competition model |
+| Status | **Not started** |
+
+### Product Hunt Launch
 
 | Field | Detail |
 |-------|--------|
 | Organiser | Product Hunt |
 | Category | Product / AI |
-| Fit | MEDIUM — good for SongPal launch visibility and product community |
-| What they offer | Visibility, community, potential featuring |
-| Eligibility | Open — product launch or hackathon entry |
-| Deadline | Various — check website |
-| Zynthio angle | SongPal AI platform launch; CoreeyAI as technical innovation |
-| Status | **Not started** |
+| Fit | MEDIUM — strong for SongPal MVP launch visibility |
+| What they offer | Visibility, community, potential featuring, investor attention |
+| Eligibility | Open |
+| Deadline | When SongPal MVP is ready for public beta |
+| Zynthio angle | SongPal AI platform launch; CoreeyAI multi-model innovation |
+| Status | **Not started** — timing dependent on SongPal readiness |
 
 ### AI for Good (ITU)
 
@@ -239,13 +272,26 @@ Before entering any competition, confirm:
 |-------|--------|
 | Organiser | ITU / United Nations |
 | Category | AI for social impact |
-| Fit | MEDIUM — education + sovereignty angle; MOSOKO democratising access to AI tools for creators |
+| Fit | MEDIUM — education + sovereignty angle |
 | What they offer | Global platform, UN visibility, partnership opportunities |
 | Eligibility | AI projects with social impact dimension |
 | Deadline | Check website |
-| Zynthio angle | MOSOKO education for independent creators; democratising AI music production; creative sovereignty |
+| Zynthio angle | MOSOKO democratising AI music education; creative sovereignty for independents globally |
 | URL | [aiforgood.itu.int](https://aiforgood.itu.int) |
 | Status | **Not started** |
+
+### Y Combinator
+
+| Field | Detail |
+|-------|--------|
+| Organiser | Y Combinator |
+| Category | Early-stage startup |
+| Fit | STRETCH — highly competitive, but Zynthio's multi-brand architecture and self-funding model stand out |
+| What they offer | $500K investment, mentorship, demo day, YC network |
+| Eligibility | Early-stage startups globally |
+| Deadline | Biannual batches (Winter/Summer) |
+| Zynthio angle | Multi-model AI orchestration, autonomous self-funding, NZ-based with global ambition |
+| Status | **Not started** — stretch goal |
 
 ---
 
@@ -255,17 +301,15 @@ Before entering any competition, confirm:
 
 | Field | Detail |
 |-------|--------|
-| Organiser | Amazon Web Services |
-| What they offer | AWS credits (up to $100K), technical support, mentorship |
+| What they offer | AWS credits (up to $100K), technical support |
 | Eligibility | Early-stage startups |
-| Zynthio angle | Infrastructure credits for SongPal scaling; AI compute |
+| Zynthio angle | Infrastructure credits for SongPal scaling |
 | Status | **Not started** — apply post-incorporation |
 
 ### Google for Startups Cloud Program
 
 | Field | Detail |
 |-------|--------|
-| Organiser | Google Cloud |
 | What they offer | GCP credits (up to $100K), technical mentorship |
 | Eligibility | Early-stage startups |
 | Zynthio angle | Cloud infrastructure for CoreeyAI and SongPal |
@@ -275,11 +319,19 @@ Before entering any competition, confirm:
 
 | Field | Detail |
 |-------|--------|
-| Organiser | Anthropic |
 | What they offer | API credits, technical support, partnership visibility |
 | Eligibility | Companies building on Claude API |
-| Zynthio angle | CoreeyAI is built on Claude as primary reasoning engine; strong product fit |
+| Zynthio angle | CoreeyAI uses Claude as primary reasoning engine |
 | Status | **Not started** — explore once SongPal MVP is live |
+
+### Microsoft for Startups (Founders Hub)
+
+| Field | Detail |
+|-------|--------|
+| What they offer | Azure credits (up to $150K), OpenAI credits, GitHub Enterprise, mentorship |
+| Eligibility | Early-stage startups |
+| Zynthio angle | Azure infrastructure, OpenAI as additional model option for CoreeyAI |
+| Status | **Not started** — apply post-incorporation |
 
 ---
 
@@ -289,22 +341,22 @@ Before entering any competition, confirm:
 
 | Period | Priority Actions |
 |--------|-----------------|
-| **May 2026** | Incorporate. Apply for Callaghan Innovation R&D Grant. Research Creative HQ and Lightning Lab deadlines. |
-| **June 2026** | Submit to Callaghan Innovation. Apply to Creative HQ or Lightning Lab (whichever has open cohort). Register for Techweek NZ. |
-| **July 2026** | Apply to Startmate (AU). Prepare SXSW Sydney application. Begin Music Ally LAUNCH application. |
-| **August 2026** | Submit SXSW Sydney. Apply to MIDEM Accelerator. Apply for cloud credits (AWS, GCP). |
-| **September 2026** | Submit to NZ Music Commission (DJ Zynrose angle). Begin Edmund Hillary Fellowship application. |
-| **October 2026** | Product Hunt launch for SongPal beta. Apply to ITU AI for Good. |
-| **November 2026** | Apply to Creative Australia Grants. Prepare NZ Hi-Tech Awards submission. |
-| **December 2026** | Review all outcomes. Plan 2027 competition strategy. Prepare for Series A positioning. |
+| **May 2026** | Incorporate. Apply Callaghan Innovation R&D Grant. Research Creative HQ / Lightning Lab deadlines. Register for Techweek NZ. |
+| **June 2026** | Submit Callaghan Innovation. Apply Creative HQ or Lightning Lab. Apply Antler Residency. Apply AWS/GCP/Microsoft credits. |
+| **July 2026** | Apply Startmate (AU). Prepare SXSW Sydney application. Begin Techstars Music application. |
+| **August 2026** | Submit SXSW Sydney. Apply MIDEM Accelerator. Apply Music Ally LAUNCH. |
+| **September 2026** | Submit NZ Music Commission (DJ Zynrose). Begin Edmund Hillary Fellowship application. Evaluate Y Combinator timing. |
+| **October 2026** | Product Hunt launch for SongPal beta. Apply ITU AI for Good. Apply Anthropic Partner programme. |
+| **November 2026** | Apply Creative Australia Grants. Prepare NZ Hi-Tech Awards. |
+| **December 2026** | Review all outcomes. Plan 2027 strategy. Position for Series A. |
 
 ---
 
 ## Tracking Notes
 
-- Update the **Dashboard** table at the top of this file as applications are submitted
-- Change status to: `Not started` → `Researching` → `Preparing` → `Submitted` → `Accepted` / `Rejected` / `Waitlisted`
-- Log outcomes and feedback in this section:
+Update the **Dashboard** table as applications progress:
+
+`Not started` → `Researching` → `Preparing` → `Submitted` → `Accepted` / `Rejected` / `Waitlisted`
 
 ### Application Log
 
@@ -316,17 +368,18 @@ Before entering any competition, confirm:
 
 ## Materials Checklist — Per Competition
 
-For each competition submission, prepare:
+For each submission, prepare:
 
 - [ ] Tailored executive summary (adapt from [COMPETITION_PORTFOLIO.md](COMPETITION_PORTFOLIO.md))
 - [ ] Pitch deck (adapt from [PITCH_DECK_OUTLINE.md](PITCH_DECK_OUTLINE.md))
 - [ ] Demo video or live demo plan (adapt from [DEMO_SCRIPT.md](DEMO_SCRIPT.md))
 - [ ] Founder bio (copy from [PRESS_KIT.md](PRESS_KIT.md))
-- [ ] Financial projections (attach [FINANCIAL_MODEL.md](FINANCIAL_MODEL.md))
+- [ ] Financial projections ([FINANCIAL_MODEL.md](FINANCIAL_MODEL.md))
+- [ ] Competition-specific angle selected (AI / fintech / music / startup)
 - [ ] Contact email added
-- [ ] Eligibility criteria confirmed
+- [ ] Eligibility confirmed
 - [ ] Word/slide/video limits checked
-- [ ] Submission deadline calendared
+- [ ] Deadline calendared
 
 ---
 

--- a/COMPETITION_PORTFOLIO.md
+++ b/COMPETITION_PORTFOLIO.md
@@ -2,56 +2,60 @@
 
 ![Status](https://img.shields.io/badge/status-ready-brightgreen) ![Updated](https://img.shields.io/badge/updated-2026--04--16-blue) ![Stage](https://img.shields.io/badge/stage-pre--seed-yellow) ![Jurisdiction](https://img.shields.io/badge/jurisdiction-New%20Zealand-black)
 
-> Full competition portfolio for startup, AI, fintech, and music technology competitions worldwide.
+> Full competition portfolio for global AI, fintech, music technology, and startup competitions.
 
 ---
 
 ## Executive Summary
 
-Zynthio is a sovereign AI-powered creative ecosystem — seven interconnected brands delivering AI music production, education, IP protection, and autonomous trading under one stack. Built by a solo NZ/AU founder-engineer-producer, incorporating in New Zealand May 2026, with live infrastructure, filed trademarks, and a ~$9.5B addressable market. Not a feature. A stack.
+Zynthio is a sovereign AI ecosystem — seven brands delivering multi-model AI orchestration, autonomous algorithmic trading, music production, and creator education under one stack. Built by a solo NZ/AU founder-engineer-producer, incorporating in New Zealand May 2026, with live infrastructure and a ~$9.5B addressable market. Not a feature. A stack.
 
 ---
 
 ## Problem Statement
 
-### The creator economy is broken in three ways:
+### AI-powered trading and creation are broken in three ways:
 
-**1. AI tools are extractive, not empowering.**
-Independent creators face AI music tools that are expensive, opaque, and designed to capture — not protect — the value of creative output. Generative AI has collapsed the cost of production, but the platforms capturing that value give nothing back.
+**1. AI trading is opaque.**
+Retail traders face algorithmic systems they cannot see, understand, or audit. Institutional players gatekeep the best models. The average retail participant is trading against black boxes — paying subscription fees for signal services with no accountability and no transparency into how decisions are made.
 
-**2. Education is disconnected from real tools.**
-Music education platforms teach theory and legacy workflows. None of them teach creators how to use the actual AI tools reshaping their industry — because those platforms don't build tools. The knowledge gap is widening.
+**2. AI trading is expensive and gatekept.**
+Sophisticated multi-model AI orchestration — the kind that routes between reasoning engines, research systems, and market analysis in real time — is available to hedge funds and prop desks. Independent traders and small teams are locked out by infrastructure costs, API complexity, and the engineering talent required to build these systems.
 
-**3. IP infrastructure is inaccessible.**
-Trademark filings, licensing agreements, and copyright strategy remain locked behind expensive legal gatekeepers. Independent artists can create at scale, but they cannot protect at scale.
+**3. AI creative tools are extractive.**
+Beyond trading, the same pattern repeats in creative industries. AI music platforms capture value from creators — expensive subscriptions, opaque models, IP-hostile terms. Education is disconnected from real tools. IP protection is inaccessible to independents. The full pipeline from creation to ownership is broken.
 
-**The result:** Creators are fragmented across disconnected, extractive tools — paying more, owning less, and building on platforms that don't serve them.
+**The result:** Whether you're an independent trader or an independent artist, you're fragmented across disconnected, extractive platforms — paying more, owning less, and building on systems that don't serve you.
 
 ---
 
 ## The Solution
 
-### Zynthio: One sovereign stack. Seven brands. Full pipeline.
+### CoreIntent + Zynthio: Open, competition-based, multi-AI orchestration.
 
-Zynthio is a vertically integrated creative-technology ecosystem that solves the fragmentation problem by combining AI production, education, IP protection, autonomous funding, and artist output under one architecture.
+**CoreIntent** is the engineering force behind Zynthio — a development studio that builds sovereign AI infrastructure for trading, creative production, and education. The core innovation is **multi-model AI orchestration**: routing tasks to the right AI engine for each job, not locking into a single vendor.
+
+**The competition model:** CoreIntent's gTrade doesn't sell signals or charge subscriptions. It operates an autonomous, risk-managed trading bot that competes in the market. Performance is the product. Results are transparent. This is the opposite of the subscription-signal model that dominates retail trading.
+
+**The sovereign stack:** Seven brands, one architecture:
 
 | Brand | Function | Status |
 |-------|----------|--------|
+| **COREINTENT** | Dev studio — engineering all systems + gTrade autonomous trading | **Live** |
+| **CoreeyAI** | Multi-model AI orchestration (Claude, Grok, Perplexity, Suno) | **Live** |
+| **SongPal** | AI-powered music production platform | In development — TM filed (IPONZ #1318588) |
+| **MOSOKO** | Education — cohort programmes and self-paced courses | Curriculum in development |
+| **KERVALON** | Legal and IP protection arm | Active |
+| **DJ Zynrose** | Artist persona — living proof of concept | Active — 2 tracks written |
 | **ZYNTHIO** | Parent company — governance, partnerships, market-facing | Incorporating May 2026 |
-| **SongPal** | AI-powered music production & collaboration platform | In development — TM filed (IPONZ #1318588) |
-| **CoreeyAI** | Multi-model AI orchestration layer (Claude, Grok, Perplexity, Suno) | Live |
-| **MOSOKO** | Music education — cohort programmes & self-paced courses | Curriculum in development |
-| **COREINTENT** | Dev studio — engineering the entire stack + autonomous trading (gTrade) | Live |
-| **KERVALON** | Legal & IP management arm | Active |
-| **DJ Zynrose** | Artist persona — living proof of concept, community builder | Active — 2 tracks written |
 
-### What makes Zynthio different:
+### What makes this different:
 
-- **Sovereign architecture** — creators own 100% of their output. No extraction.
-- **Multi-AI orchestration** — CoreeyAI routes tasks across Claude, Grok, Perplexity, and Suno. Not a wrapper. Purpose-built.
-- **Closed-loop ecosystem** — Build (COREINTENT) → Think (CoreeyAI) → Create (SongPal + DJ Zynrose) → Teach (MOSOKO) → Protect (KERVALON) → Scale (ZYNTHIO).
-- **Self-funding mechanism** — gTrade autonomous trading bot provides internal development funding without external dependency.
-- **Competition model** — gTrade operates on risk-managed, competition-based algorithmic trading, not subscription-based signal services. Performance is the product.
+- **Open architecture** — multi-model AI, no vendor lock-in, public documentation
+- **Competition model** — gTrade competes on performance, not subscriptions. No signal-selling.
+- **Sovereign infrastructure** — own servers, own deployment, own data. Not renting from AWS/GCP.
+- **Closed-loop ecosystem** — Build (COREINTENT) → Think (CoreeyAI) → Create (SongPal) → Teach (MOSOKO) → Protect (KERVALON) → Scale (ZYNTHIO)
+- **Self-funding** — gTrade autonomously funds development. Not dependent on venture capital to survive.
 
 ---
 
@@ -62,12 +66,16 @@ Zynthio is a vertically integrated creative-technology ecosystem that solves the
 | Global music production software | $5.9B | ~8% YoY |
 | AI music generation | $1.5B | ~25% YoY |
 | Online music education | $2.1B | ~10% YoY |
-| **Total Addressable Market** | **~$9.5B** | |
+| Global retail trading platforms | $12.1B | ~6% YoY |
+| AI-assisted investing tools | $3.8B | ~20% YoY |
+| **Total Addressable Market** | **~$9.5B** (creative stack) | |
+| **Extended TAM** (incl. trading) | **~$25.4B** | |
 
 ### Why now:
 
-- Generative AI has collapsed the cost of music creation — the bottleneck is now **curation, pedagogy, and IP infrastructure**
-- No competitor offers a vertically integrated creator stack — the market is fragmented by design
+- Generative AI has collapsed costs in both trading and music creation — the bottleneck is now **curation, orchestration, and infrastructure**
+- Multi-model AI orchestration is technically feasible but no one is packaging it for independents
+- Retail trading volume is at all-time highs but tools have not caught up
 - Independent creators are the fastest-growing segment of the music industry
 - NZ/AU tech ecosystems are underserved by global AI tools built for US/EU markets
 
@@ -80,13 +88,13 @@ Zynthio is a vertically integrated creative-technology ecosystem that solves the
 | Field | Detail |
 |-------|--------|
 | Citizenship | New Zealand / Australia (dual) |
-| Current location | Managua, Nicaragua |
+| Current location | Managua, Nicaragua (operating globally) |
 | Role | Sole founder — architecture, code, brand, and music |
-| Technical | Full-stack developer, AI engineer, Python/Docker/CI-CD |
-| Creative | Independent music producer (DJ Zynrose) |
+| Technical | Full-stack developer, AI engineer — Next.js, Python, Docker, multi-model AI |
+| Creative | Independent music producer (DJ Zynrose) — electronic / experimental / ambient |
 | GitHub | [coreintentdev](https://github.com/coreintentdev) |
 
-**Why one founder matters:** Corey built the entire stack — the AI integrations, the production infrastructure, the brand architecture, the documentation, the music, and the legal filings. This is not a pitch deck looking for an engineer. The engineer is the founder.
+**Why one founder matters:** Corey built the entire stack — the AI orchestration, the trading engine, the production infrastructure, the brand architecture, the documentation, the music, and the legal filings. This is not a pitch deck looking for an engineer. The engineer is the founder.
 
 **Director qualification:** NZ/AU citizen — qualifies as eligible director under NZ Companies Act 1993 s 10(2A), regardless of physical location.
 
@@ -102,38 +110,40 @@ Zynthio is a vertically integrated creative-technology ecosystem that solves the
                     │ (consumed via)
 ┌───────────────────▼────────────────────────────────────────────┐
 │                       CoreeyAI                                 │
-│     Model orchestration · Prompt engineering · Agentic flows   │
+│     Multi-model orchestration · Prompt routing · Agentic flows │
 └──────────┬────────────────────────────┬───────────────────────┘
            │                            │
 ┌──────────▼──────────┐     ┌───────────▼────────────────────────┐
 │       SongPal       │     │             MOSOKO                  │
 │  AI music platform  │     │   Adaptive learning engine          │
+│    (Next.js UI)     │     │     (Next.js frontend)              │
 └─────────────────────┘     └────────────────────────────────────┘
 
 ┌────────────────────────────────────────────────────────────────┐
 │                    COREINTENT INFRASTRUCTURE                   │
-│   Python 3.11 · Docker · VPS (104.194.156.109) · GitHub CI    │
+│   Next.js · Python 3.11 · Docker · VPS · GitHub CI            │
 │   gTrade (autonomous trading) · Perplexity Orb · Master Docs  │
 └────────────────────────────────────────────────────────────────┘
 ```
 
 | Layer | Technologies |
 |-------|-------------|
-| Primary language | Python 3.11 |
-| AI orchestration | Claude API, Grok API, Perplexity, Suno API |
-| Infrastructure | Docker, Docker Compose, VPS (104.194.156.109) |
+| Frontend | Next.js (React), TypeScript |
+| Backend / AI | Python 3.11, multi-model API orchestration |
+| AI services | Claude API, Grok API, Perplexity, Suno API |
+| Infrastructure | Docker, Docker Compose, sovereign VPS |
 | Version control | Git / GitHub ([coreintentdev](https://github.com/coreintentdev)) |
-| Agentic systems | Perplexity Orb — session management, multi-step AI workflows |
+| Agentic systems | Perplexity Orb — session management, multi-step workflows |
 | Trading engine | gTrade — risk-managed autonomous bot (BTC, ETH, SOL, XAU, XAG) |
 | Config | YAML, .env |
 | Monitoring | JSON logging, health checks |
 
 ### Key architectural decisions:
 
-- **Multi-model AI** — no single-vendor lock-in. CoreeyAI routes to the best model for each task.
-- **Sovereign infrastructure** — own VPS, own deployment pipeline, own data.
-- **Modular brand architecture** — each brand pulls from CoreeyAI for the intelligence it needs.
-- **Open-source documentation** — ZYNTHIO_MASTER_DOCS is public. Transparency is a feature.
+- **Multi-model AI** — no single-vendor lock-in. CoreeyAI routes to the best model per task: Claude for reasoning, Grok for real-time market sentiment, Perplexity for research, Suno for audio generation.
+- **Next.js frontend** — modern, performant UI layer for SongPal and MOSOKO. Server-side rendering, edge-ready.
+- **Sovereign infrastructure** — own VPS, own deployment pipeline, own data. Not renting someone else's cloud.
+- **Open documentation** — ZYNTHIO_MASTER_DOCS is public on GitHub. Transparency as a feature, not a liability.
 
 ---
 
@@ -141,33 +151,34 @@ Zynthio is a vertically integrated creative-technology ecosystem that solves the
 
 ### 1. Competition Model vs. Subscription
 
-gTrade operates on a performance-based competition model — autonomous, risk-managed algorithmic trading that funds development. This is not a subscription signal service. The bot competes in the market and the results speak for themselves.
+gTrade operates on a **performance-based competition model** — autonomous, risk-managed algorithmic trading that funds development. This is fundamentally different from the subscription-signal model. There are no monthly fees for signals of questionable quality. The bot competes in the market and the results speak for themselves. Max leverage 5.0x. 1% max risk per trade. 0.8% daily loss ceiling. Disciplined, transparent, auditable.
 
 ### 2. NZ Jurisdiction
 
-- Incorporating under NZ Companies Act 1993 — strong corporate governance framework
+- Incorporating under NZ Companies Act 1993 — strong, transparent corporate governance
 - IPONZ trademark protection (SongPal #1318588)
-- NZ/AU tech and export education incentives
-- Founder holds NZ/AU dual citizenship — deep jurisdictional alignment
+- NZ's export education and tech incentive frameworks align with MOSOKO and SongPal
+- Founder holds NZ/AU dual citizenship — deep jurisdictional alignment, not a flag-of-convenience incorporation
 
 ### 3. Open Architecture
 
-- Public documentation repository ([ZYNTHIO_MASTER_DOCS](https://github.com/coreintentdev/zynthio_master_docs))
-- MIT-licensed codebase
-- Multi-model AI — no vendor lock-in
-- Creator sovereignty — users own 100% of their output
+- **Public documentation** — [ZYNTHIO_MASTER_DOCS](https://github.com/coreintentdev/zynthio_master_docs) is open on GitHub
+- **Multi-model AI** — no vendor lock-in. Switch or add models without rewriting the stack.
+- **Creator sovereignty** — users own 100% of their output. No extraction, no IP capture.
+- **MIT-licensed codebase** — open by default
 
 ### 4. Vertical Integration
 
-No competitor combines AI production + education + IP infrastructure + an artist persona + autonomous trading under one sovereign architecture.
+No competitor combines AI orchestration + autonomous trading + music production + education + IP protection + an artist persona under one sovereign architecture.
 
 | Competitor | What They Do | What Zynthio Does Differently |
 |------------|-------------|-------------------------------|
 | Suno / Udio | AI music generation | Integrates generation *within* a full creator stack |
-| Splice | Sample library & collaboration | AI-native and sovereignty-focused — creators own output |
+| Splice | Sample library & collaboration | AI-native, sovereignty-focused — creators own output |
 | Berklee Online | Music education | MOSOKO teaches *this specific stack* — tools are live products |
 | LANDR | AI mastering & distribution | Full pipeline: creation → education → legal → distribution |
-| Generic AI APIs | Model access | Zynthio is the *application layer* — purpose-built for creators |
+| Signal-selling bots | Subscription signals | gTrade competes on performance — no subscriptions, no signal-selling |
+| Generic AI APIs | Raw model access | Zynthio is the *application layer* — purpose-built, not generic |
 
 ---
 
@@ -177,29 +188,24 @@ No competitor combines AI production + education + IP infrastructure + an artist
 
 ### Live & Operational
 
-- **Production infrastructure:** VPS 104.194.156.109 — Docker, Python 3.11, deployment pipeline running
+- **Production infrastructure:** Sovereign VPS — Docker, Python 3.11, deployment pipeline running
 - **AI integrations:** Claude, Grok, Perplexity all active and wired into CoreeyAI
 - **gTrade autonomous trading bot:** Live and operating — self-funding development
-- **Perplexity Orb:** Agentic session management deployed
-- **ZYNTHIO_MASTER_DOCS:** Comprehensive documentation for 7 brands, public on GitHub
+- **Perplexity Orb:** Agentic session management deployed and operational
+- **ZYNTHIO_MASTER_DOCS:** 7-brand architecture fully documented, public on GitHub
+- **Domain secured:** zynthio.ai — active
 
 ### Filed & In Process
 
 - **Trademark filed:** SongPal — IPONZ #1318588 (awaiting examination)
 - **Company name reserved:** ZYNTHIO LIMITED — NZCO #15436626 (incorporating before May 12, 2026)
-- **Domain secured:** zynthio.ai — active
 
 ### In Development
 
-- **SongPal platform:** MVP build underway — target beta Q2–Q3 2026
+- **SongPal platform:** Next.js MVP build underway — target beta Q2–Q3 2026
 - **MOSOKO curriculum:** First cohort target Q3 2026
 - **Original music:** *SIGNAL 336* and *THE MIRROR ASKED A QUESTION* written, 4-platform deployment pipeline in progress
-
-### Content & Community
-
-- **19 avatar scripts** across 6 languages (EN, ES, FR, PT, ZH, MI)
-- **Seven-brand architecture** fully documented with brand guidelines, roadmaps, and asset registries
-- **Open-source presence:** [github.com/coreintentdev](https://github.com/coreintentdev)
+- **19 multilingual avatar scripts** across 6 languages (EN, ES, FR, PT, ZH, MI)
 
 ### What we don't have yet (and we're honest about it):
 
@@ -208,6 +214,8 @@ No competitor combines AI production + education + IP infrastructure + an artist
 - Solo founder (no team hires yet)
 - SongPal beta not yet launched
 - No streaming platform presence for DJ Zynrose (deployment pending)
+
+We're early. The architecture is real. The infrastructure is running. The honesty is deliberate.
 
 ---
 
@@ -230,7 +238,7 @@ No competitor combines AI production + education + IP infrastructure + an artist
 | Free → paid conversion | 10–15% |
 | CAC | NZD $30–50 |
 | 12-month LTV | NZD $240–360 |
-| LTV:CAC ratio | 6–8× |
+| LTV:CAC ratio | 6–8x |
 
 ### Funding Ask
 
@@ -241,7 +249,7 @@ No competitor combines AI production + education + IP infrastructure + an artist
 
 **Current monthly burn:** ~NZD $280–480. At $150K raise, runway = 20–35 months to MRR breakeven.
 
-→ Full details: [FINANCIAL_MODEL.md](FINANCIAL_MODEL.md)
+-> Full details: [FINANCIAL_MODEL.md](FINANCIAL_MODEL.md)
 
 ---
 
@@ -250,10 +258,10 @@ No competitor combines AI production + education + IP infrastructure + an artist
 | Competition Type | What We're Seeking |
 |-----------------|--------------------|
 | **Startup competition** | Seed capital / accelerator access — target NZD $150–250K |
-| **AI competition** | Recognition, partnerships, API credits |
-| **Music / creative tech** | Industry exposure, label/distributor introductions |
-| **Fintech / trading** | Recognition for gTrade's autonomous trading architecture |
-| **Legal / IP innovation** | Pro-bono IP counsel, IPONZ support |
+| **AI competition** | Recognition, partnerships, API credits, multi-model orchestration validation |
+| **Fintech / trading** | Recognition for gTrade's autonomous, competition-based trading architecture |
+| **Music / creative tech** | Industry exposure, label/distributor introductions, SongPal partnerships |
+| **Education** | MOSOKO curriculum partnerships, institutional pilot programmes |
 
 ---
 
@@ -272,11 +280,12 @@ Email: *(add contact email before submitting)*
 |----------|---------|
 | [PITCH_DECK_OUTLINE.md](PITCH_DECK_OUTLINE.md) | 10-slide pitch deck structure |
 | [DEMO_SCRIPT.md](DEMO_SCRIPT.md) | 3-minute live demo walkthrough |
-| [PRESS_KIT.md](PRESS_KIT.md) | Brand story, founder bio, key quotes |
+| [PRESS_KIT.md](PRESS_KIT.md) | Brand story, founder bio, key quotes, brand colours |
 | [AWARDS_TRACKER.md](AWARDS_TRACKER.md) | 2026 competition targets and deadlines |
+| [COMPETITION_ENTRY.md](COMPETITION_ENTRY.md) | One-page summary and 30-second spoken pitch |
 | [FINANCIAL_MODEL.md](FINANCIAL_MODEL.md) | 3-year revenue projections |
 | [ECOSYSTEM_MAP.md](ECOSYSTEM_MAP.md) | Full brand architecture |
-| [NZ_COMPLIANCE.md](NZ_COMPLIANCE.md) | Incorporation & IP tracker |
+| [NZ_COMPLIANCE.md](NZ_COMPLIANCE.md) | Incorporation and IP tracker |
 
 ---
 

--- a/DEMO_SCRIPT.md
+++ b/DEMO_SCRIPT.md
@@ -3,196 +3,211 @@
 ![Status](https://img.shields.io/badge/status-ready-brightgreen) ![Updated](https://img.shields.io/badge/updated-2026--04--16-blue) ![Duration](https://img.shields.io/badge/duration-3%20minutes-purple)
 
 > 3-minute live demo walkthrough for competitions, investor meetings, and showcases.
-> Designed to show the real stack — not a prototype, not a mockup.
+> This is not a mockup tour. This is live infrastructure, running in production.
 
 ---
 
 ## Pre-Demo Checklist
 
-Before going live, confirm:
-
-- [ ] VPS (104.194.156.109) is accessible and services are running
+- [ ] VPS accessible and services running (Docker containers healthy)
 - [ ] CoreeyAI integrations responding (Claude, Grok, Perplexity)
 - [ ] ZYNTHIO_MASTER_DOCS GitHub repo is public and loaded
 - [ ] SongPal demo environment ready (or fallback: architecture walkthrough)
-- [ ] gTrade dashboard accessible (or fallback: risk config display)
+- [ ] gTrade dashboard / risk config accessible
 - [ ] Browser tabs pre-loaded: zynthio.ai, GitHub repo, VPS terminal, SongPal (if available)
 - [ ] Audio output tested (for music playback segment)
 - [ ] Backup: offline screenshots / screen recording if WiFi fails
+- [ ] Timer visible to speaker (3:00 countdown)
 
 ---
 
 ## Demo Flow — 3 Minutes
 
-### [0:00–0:20] Opening — Set the Frame
+### [0:00–0:20] Opening — This Is Real
 
 **Say:**
 
-> "Let me show you what Zynthio actually looks like under the hood. This isn't a mockup — this is live infrastructure, running right now on our own server in production."
+> "Everything I'm about to show you is live. Real server. Real AI integrations. Real trading bot. Not a prototype — production infrastructure, running right now."
 
-**Action:** Open terminal or browser showing VPS status / Docker containers running.
+**Action:** Open terminal showing VPS. Run `docker ps` — containers running, health checks green.
 
-**Show:** Docker container list — services running, health checks passing. The audience sees real infrastructure, not slides.
+**Impact:** The audience sees infrastructure, not slides. Credibility is established in the first 15 seconds.
 
 ---
 
-### [0:20–0:50] The Intelligence Layer — CoreeyAI
+### [0:20–0:55] CoreeyAI — Multi-Model AI Orchestration
 
 **Say:**
 
-> "This is CoreeyAI — our AI orchestration layer. It doesn't just call one API. It routes tasks to the right model for the job."
+> "This is CoreeyAI — our AI orchestration layer. Most AI products call one API. We route to the right model for each job."
 
-**Action:** Trigger a live CoreeyAI query — send a prompt that demonstrates model routing.
-
-**Show:**
-- A composition prompt sent to CoreeyAI
-- CoreeyAI routing to Claude for arrangement logic, Perplexity for genre research
-- Response returned with structured output
+**Action:** Trigger a live CoreeyAI query. Show multi-model routing in action:
+- Send a composition prompt
+- CoreeyAI routes to Claude for arrangement reasoning, Perplexity for genre context
+- Structured response returned
 
 **Say:**
 
-> "That's three AI models, orchestrated in one call. Claude for reasoning, Perplexity for research, Suno for generation. This is what powers SongPal."
+> "Claude for reasoning. Grok for real-time market analysis. Perplexity for deep research. Suno for audio generation. Four models, one orchestration layer, purpose-built routing. That's what powers everything in this stack."
+
+**Action:** If time allows, show a second query — a market analysis prompt routed through Grok to demonstrate the trading intelligence angle.
 
 ---
 
-### [0:50–1:30] The Product — SongPal
+### [0:55–1:35] SongPal — The Product
 
 **If SongPal MVP is ready:**
 
 **Say:**
 
-> "This is SongPal — our AI music production platform. Trademark filed in New Zealand. Let me show you what it feels like to create with it."
+> "This is SongPal — our AI music production platform. Trademark filed in New Zealand. Built on Next.js with CoreeyAI underneath."
 
-**Action:** Open SongPal interface. Demonstrate:
-1. Start a new track session
-2. Enter a creative prompt (e.g., "ambient electronic, 120 BPM, atmospheric pads, minimal percussion")
-3. Show CoreeyAI processing the prompt
-4. Play back the generated audio snippet
+**Action:**
+1. Open SongPal interface
+2. Enter a creative prompt: "ambient electronic, 120 BPM, atmospheric pads, minimal percussion"
+3. Show CoreeyAI processing the prompt — multi-model routing visible
+4. Play back the generated audio
 
 **Say:**
 
-> "That's original audio, created in seconds, using our own AI layer. The creator owns 100% of it. No licensing traps. No extraction."
+> "Original audio. Created in seconds. The creator owns 100% of it. No licensing traps. No extraction. No subscription lock-in."
 
 **If SongPal MVP is not yet ready (fallback):**
 
 **Say:**
 
-> "SongPal is in active development — trademark filed, beta targeting this quarter. Let me show you the architecture that powers it."
+> "SongPal is in active development — trademark filed, Next.js MVP targeting beta this quarter. Let me show you the architecture."
 
-**Action:** Show the ECOSYSTEM_MAP.md architecture diagram on GitHub. Walk through the data flow:
-- COREINTENT builds → CoreeyAI thinks → SongPal creates → MOSOKO teaches → KERVALON protects
+**Action:** Show ECOSYSTEM_MAP.md on GitHub. Walk through the data flow diagram.
 
-**Play:** A 15-second clip of *SIGNAL 336* or *THE MIRROR ASKED A QUESTION*.
+**Then play:** A 15-second clip of *SIGNAL 336* or *THE MIRROR ASKED A QUESTION*.
 
 **Say:**
 
-> "This track was made using the Zynthio stack. DJ Zynrose — the founder's artist project — is the living proof of concept. Every track is made on the same tools we're building for everyone."
+> "This track was made using the Zynthio stack. DJ Zynrose is the founder's artist project — the living proof of concept. Same tools we're building for everyone."
 
 ---
 
-### [1:30–2:00] The Self-Funding Engine — gTrade
+### [1:35–2:10] gTrade — The Competition Model
 
 **Say:**
 
-> "Most early-stage startups burn cash while they build. We built a different mechanism."
+> "Here's where Zynthio gets interesting for the business model. Most startups burn cash while they build. We built a different mechanism."
 
-**Action:** Show gTrade dashboard or risk configuration (config/risk.yaml).
+**Action:** Show gTrade risk configuration:
 
-**Show:**
-- Asset coverage: BTC-PERP, ETH-PERP, SOL-PERP, XAU-PERP, XAG-PERP
-- Risk parameters: max leverage 5.0×, 1% max risk per trade, 0.8% daily loss ceiling
-- Status: live, autonomous, risk-managed
+```
+Assets:     BTC-PERP, ETH-PERP, SOL-PERP, XAU-PERP, XAG-PERP
+Max lever:  5.0x
+Risk/trade: 1% max
+Daily loss: 0.8% ceiling
+Status:     LIVE — autonomous
+```
 
 **Say:**
 
-> "gTrade is our autonomous trading bot. It operates on a competition-based model — risk-managed, disciplined, and it self-funds our development. This isn't a side project. It's how we stay sovereign while we build."
+> "gTrade is our autonomous trading bot. It doesn't sell signals. It doesn't charge subscriptions. It competes in the market — risk-managed, disciplined, and it self-funds our development. This is the competition model versus the subscription model. Performance is the product."
 
 ---
 
-### [2:00–2:30] The Documentation & Brand Architecture
+### [2:10–2:35] Documentation & Open Architecture
 
 **Say:**
 
-> "One thing that sets Zynthio apart — everything is documented, public, and structured."
+> "One more thing. Everything is documented, public, and structured."
 
-**Action:** Open GitHub repo (ZYNTHIO_MASTER_DOCS). Scroll through:
-- INDEX.md — master table of contents
-- 7 brand directories, each with README, ROADMAP, ASSETS
-- 19 multilingual avatar scripts (6 languages)
+**Action:** Open GitHub repo. Quick scroll:
+- INDEX.md — master contents
+- 7 brand directories with README, ROADMAP, ASSETS
 - FINANCIAL_MODEL.md, NZ_COMPLIANCE.md
+- 19 avatar scripts across 6 languages
 
 **Say:**
 
-> "Seven brands. Full documentation. Brand guidelines, roadmaps, financial projections, NZ compliance tracking — all in one public repo. This is how you build a real company, not just a demo."
+> "Seven brands. Full documentation. Brand guidelines, roadmaps, financial projections, NZ compliance tracking. Open architecture. MIT-licensed. This is how you build a real company."
 
 ---
 
-### [2:30–3:00] Close — The Stack Is Real
+### [2:35–3:00] Close — The Stack Is Real
 
 **Say:**
 
-> "Let me leave you with this. What you just saw is not a pitch deck. It's a running system."
+> "What you just saw is not a pitch deck. It's a running system."
 
-**Action:** Return to the terminal / VPS view. Services running.
+**Action:** Return to terminal. Services running.
 
 **Say:**
 
-> "Live infrastructure. Multi-model AI. A trademark on file. A company incorporating in New Zealand this month. Original music written and ready to deploy. And a founder who built every layer — the code, the brand, the music, and the legal filings."
+> "Live infrastructure. Multi-model AI orchestration. An autonomous trading bot that funds its own development. A trademark on file. A company incorporating in New Zealand this month. Original music. And a founder who built every layer — the code, the AI, the trading engine, the brand, the music, and the legal filings."
 
-> "Zynthio is not a feature. It's a sovereign creative stack for the post-AI world."
+**Pause.**
 
-**Pause. Make eye contact.**
+> "One stack. Seven brands. Competition model, not subscription. Open architecture, not vendor lock-in."
 
-> "One stack. Seven brands. No filler. All signal."
+**Final beat:**
+
+> "No filler. All signal."
 
 ---
 
 ## Timing Summary
 
-| Segment | Duration | Focus |
-|---------|----------|-------|
+| Segment | Time | Focus |
+|---------|------|-------|
 | Opening — live infrastructure | 0:00–0:20 | Credibility — real server, real containers |
-| CoreeyAI — AI orchestration | 0:20–0:50 | Technical depth — multi-model routing |
-| SongPal — the product | 0:50–1:30 | Product demo or architecture + music |
-| gTrade — self-funding | 1:30–2:00 | Business model — sovereign funding |
-| Documentation & brand | 2:00–2:30 | Professionalism — structured, public, real |
-| Close — the stack is real | 2:30–3:00 | Impact — tie it together |
+| CoreeyAI — multi-model orchestration | 0:20–0:55 | Technical depth — multi-model routing, not a wrapper |
+| SongPal — the product | 0:55–1:35 | Product demo or architecture + music playback |
+| gTrade — competition model | 1:35–2:10 | Business model — sovereign funding, performance-based |
+| Documentation & open architecture | 2:10–2:35 | Professionalism — structured, public, MIT-licensed |
+| Close — the stack is real | 2:35–3:00 | Impact — tie everything together |
 
 ---
 
-## Adaptation Notes
+## Adaptation by Competition Type
 
-### For AI competitions (emphasise CoreeyAI):
-- Extend the CoreeyAI segment to 60 seconds
-- Show prompt engineering templates and agentic workflow (Perplexity Orb)
+### For fintech / trading competitions:
+- Open with gTrade — lead with the competition model
+- Extend gTrade segment to 45 seconds — show risk params, asset coverage, autonomous operation
+- Show CoreeyAI's market analysis routing (Grok for sentiment, Perplexity for research)
+- Trim SongPal to 20 seconds — mention it as proof of multi-domain capability
+- Close with: "Competition model beats subscription. Performance is the product."
+
+### For AI competitions:
+- Lead with CoreeyAI — multi-model orchestration is the headline
+- Show prompt routing across 3+ models in a single query
+- Demonstrate Perplexity Orb agentic workflows
 - Trim gTrade to 15 seconds
+- Close with: "Four models. One orchestration layer. Purpose-built, not a wrapper."
 
-### For music competitions (emphasise SongPal + DJ Zynrose):
-- Lead with music playback — open with 10 seconds of *SIGNAL 336*
-- Extend SongPal segment to 60 seconds
+### For music / creative tech competitions:
+- Open with 10 seconds of *SIGNAL 336* — music first
+- Extend SongPal to 60 seconds — demo or walkthrough
 - Show MOSOKO curriculum outline
-- Trim gTrade and documentation segments
+- Introduce DJ Zynrose as the proof of concept
+- Close with: "The artist is the engineer. The stack is the instrument."
 
-### For startup/fintech competitions (emphasise business model):
-- Lead with market size ($9.5B)
-- Extend gTrade segment — show risk parameters and autonomous operation
-- Show FINANCIAL_MODEL.md projections on screen
-- Close with funding ask
+### For startup competitions:
+- Lead with market size ($9.5B creative, $25B+ with trading)
+- Balance time across all segments — show breadth of the ecosystem
+- Emphasise self-funding via gTrade (lean burn, sovereign)
+- Close with the funding ask: NZD $150–250K
 
 ### If WiFi fails:
 - Pre-record a 3-minute screen capture as backup
-- Have offline screenshots of all key screens
-- Music clips stored locally on device
+- Have offline screenshots of all key screens saved locally
+- Music clips stored on device
+- PDF of ECOSYSTEM_MAP.md available offline
 
 ---
 
-## Key Quotes to Land
+## Key Lines to Land
 
-Use one or two of these during the demo, depending on audience:
+Pick one or two per demo, matched to audience:
 
 - *"The engineer is the artist. The person building the tools is the person using them."*
-- *"We don't burn cash while we build. gTrade funds our development autonomously."*
+- *"We don't sell signals. We compete. Performance is the product."*
 - *"This is not a pitch deck looking for an engineer. The engineer is the founder."*
+- *"Competition model, not subscription. Open architecture, not lock-in."*
 - *"No filler. All signal."*
 
 ---

--- a/PITCH_DECK_OUTLINE.md
+++ b/PITCH_DECK_OUTLINE.md
@@ -2,8 +2,8 @@
 
 ![Status](https://img.shields.io/badge/status-ready-brightgreen) ![Updated](https://img.shields.io/badge/updated-2026--04--16-blue) ![Slides](https://img.shields.io/badge/slides-10-purple)
 
-> 10-slide pitch deck structure with full content for each slide.
-> Designed for startup, AI, and music technology competitions.
+> 10-slide pitch deck with full content for each slide.
+> Designed for startup, AI, fintech, and music technology competitions.
 > Adapt per competition — trim or expand as format requires.
 
 ---
@@ -12,9 +12,9 @@
 
 ### ZYNTHIO
 
-**Tagline:** *The sovereign creative stack.*
+**Tagline:** *No filler. All signal.*
 
-**Subtitle:** AI-powered music production, education, and IP protection — one ecosystem, seven brands, built by one founder.
+**Subtitle:** Multi-model AI orchestration for trading, music production, and creator sovereignty — one stack, seven brands, built by one founder.
 
 **Visual:** Zynthio wordmark on #0A0A0A background. Signal Gold (#C9A84C) accent line. Domain: zynthio.ai
 
@@ -24,58 +24,62 @@
 
 ## Slide 2 — The Problem
 
-### Independent creators are fragmented across broken tooling.
+### The tools are getting smarter. The systems around them are getting worse.
 
-**Three pain points:**
+**Three structural failures:**
 
-1. **AI tools are extractive.** Generative music platforms capture value from creators — expensive subscriptions, opaque models, IP-hostile terms. Creators produce; platforms profit.
+1. **AI trading is opaque and gatekept.** Multi-model AI orchestration exists — for hedge funds and prop desks. Retail traders get black-box signals on subscription. No transparency. No accountability. No way to audit how decisions are made.
 
-2. **Education is disconnected.** Music schools teach legacy workflows. None of them teach the AI tools reshaping the industry — because they don't build tools.
+2. **AI creative tools are extractive.** Generative music platforms capture value from creators. Expensive subscriptions, opaque models, IP-hostile terms. Creators produce; platforms profit.
 
-3. **IP protection is inaccessible.** Trademarks, licensing, and copyright strategy are locked behind expensive legal gatekeepers. Creators can produce at scale but cannot protect at scale.
+3. **Education and IP are afterthoughts.** Music schools teach legacy workflows. Legal protection is locked behind expensive gatekeepers. Creators can produce at scale but cannot learn or protect at scale.
 
-**Key stat:** The global music production + AI music + online education market is worth **~$9.5 billion** — and no one offers the full stack.
+**Key stat:** The combined market across music production, AI music, education, retail trading, and AI-assisted investing exceeds **$25 billion** — and no one offers the integrated stack.
 
-**Visual:** Three icons (lock, broken chain, shield with X). Simple, dark background.
+**Visual:** Three icons (locked vault, broken chain, blind eye). Dark background. Minimal.
 
 ---
 
 ## Slide 3 — The Solution
 
-### Zynthio: One stack. Seven brands. Full pipeline.
+### CoreIntent builds it. Zynthio ships it.
 
-**Architecture diagram:**
+**CoreIntent** is the engineering arm of Zynthio — a development studio that builds sovereign AI infrastructure using **multi-model orchestration**. Not locked to one AI vendor. Not selling signals. Not extracting from creators.
+
+**The stack:**
 
 ```
-ZYNTHIO (Parent)
+ZYNTHIO (Parent — NZ incorporated)
+├── COREINTENT — Dev studio + gTrade autonomous trading
+├── CoreeyAI — Multi-model AI orchestration (Claude, Grok, Perplexity, Suno)
 ├── SongPal — AI music production platform (TM filed)
-├── CoreeyAI — Multi-model AI orchestration
 ├── MOSOKO — Education for sovereign creators
 ├── DJ Zynrose — Artist persona + proof of concept
-├── COREINTENT — Dev studio + autonomous trading (gTrade)
 ├── KERVALON — Legal & IP protection
 ```
 
-**Key message:** Zynthio is not a product. It is infrastructure for creative sovereignty. Build → Think → Create → Teach → Protect → Scale. Every brand reinforces every other.
+**Key message:** This is not a product. It is infrastructure. Build → Think → Create → Teach → Protect → Scale. Every brand reinforces every other.
 
-**Visual:** Clean architecture diagram with Signal Gold connections between brands on dark background.
+**Visual:** Architecture diagram with Signal Gold connections on dark background.
 
 ---
 
 ## Slide 4 — How It Works
 
-### The closed-loop creator journey.
+### The closed-loop system.
 
-| Step | Brand | Action |
-|------|-------|--------|
-| 1. **Build** | COREINTENT | Engineers world-class tools |
-| 2. **Think** | CoreeyAI | Makes the tools intelligent (Claude, Grok, Perplexity, Suno) |
-| 3. **Create** | SongPal + DJ Zynrose | Produces music with AI assistance |
-| 4. **Teach** | MOSOKO | Spreads the capability to independent creators |
+| Step | Brand | What Happens |
+|------|-------|-------------|
+| 1. **Build** | COREINTENT | Engineers the tools + operates gTrade autonomous trading |
+| 2. **Think** | CoreeyAI | Routes tasks to the right AI — Claude for reasoning, Grok for markets, Perplexity for research, Suno for audio |
+| 3. **Create** | SongPal + DJ Zynrose | Produces music with multi-model AI assistance |
+| 4. **Teach** | MOSOKO | Teaches independent creators to use the full stack |
 | 5. **Protect** | KERVALON | Locks in IP value — trademarks, copyright, licensing |
-| 6. **Scale** | ZYNTHIO | Takes the whole stack to market |
+| 6. **Scale** | ZYNTHIO | Takes the whole system to market |
 
-**Key differentiator:** DJ Zynrose is the living proof of concept. Every track is made on SongPal, taught through MOSOKO, and protected by KERVALON. The artist *is* the product demo.
+**The competition model:** gTrade doesn't sell signals. It competes autonomously in the market — risk-managed, disciplined, transparent. Performance is the product.
+
+**The artist test:** DJ Zynrose is the founder's artist project. Every track is made on SongPal, taught through MOSOKO, protected by KERVALON. The artist *is* the product demo.
 
 **Visual:** Circular flow diagram. Six steps, Signal Gold arrows, brand logos at each node.
 
@@ -83,31 +87,34 @@ ZYNTHIO (Parent)
 
 ## Slide 5 — Market Opportunity
 
-### ~$9.5B Total Addressable Market
+### $9.5B creative stack. $25B+ with trading.
 
 | Segment | Size (2025) | Growth |
 |---------|------------|--------|
 | Music production software | $5.9B | +8% YoY |
 | AI music generation | $1.5B | +25% YoY |
 | Online music education | $2.1B | +10% YoY |
+| Retail trading platforms | $12.1B | +6% YoY |
+| AI-assisted investing | $3.8B | +20% YoY |
 
 **Why now:**
-- Generative AI has collapsed production costs — the bottleneck is now curation, pedagogy, and IP
-- Independent creators are the fastest-growing music segment
-- No competitor offers a vertically integrated sovereign stack
+- Multi-model AI orchestration is technically feasible — but nobody packages it for independents
+- Generative AI collapsed production costs — the bottleneck is orchestration, curation, and IP
+- Independent creators and retail traders are the fastest-growing segments in their respective markets
+- The subscription-signal model in trading is ripe for disruption by performance-based competition
 
-**Comparable exits / benchmarks:**
+**Comparable benchmarks:**
 - LANDR (Series B): $10M+ ARR — AI audio tools
 - Splice (Growth): $50M+ ARR — creator tools SaaS
 - Berklee Online: $40M+ ARR — music education
 
-**Visual:** Market size bars with Zynthio's position highlighted. Growth arrows on AI segment.
+**Visual:** Market size bars with Zynthio's position highlighted. Growth arrows on AI segments.
 
 ---
 
 ## Slide 6 — Business Model
 
-### Four revenue streams across three brands.
+### Four revenue streams. One internal funding engine.
 
 | Stream | Brand | Model | Target Launch |
 |--------|-------|-------|---------------|
@@ -116,111 +123,114 @@ ZYNTHIO (Parent)
 | **CoreeyAI API** | CoreeyAI | B2B per-call or monthly licensing | Q4 2026 |
 | **KERVALON Services** | KERVALON | IP consulting + TM filing for indie artists | Q4 2026+ |
 
-**Internal funding:** gTrade autonomous trading bot (live) self-funds development. Not included in revenue projections.
+**Internal funding engine:** gTrade autonomous trading bot (live) self-funds development. Not included in revenue projections. This is how we stay sovereign while we build — no VC dependency to keep the lights on.
 
 **Unit economics (SongPal):**
 - ARPU: NZD $20–30/mo
-- Target LTV:CAC: 6–8×
+- Target LTV:CAC: 6–8x
 - 12-month LTV: NZD $240–360
 
-**Visual:** Revenue stream diagram with brand-coloured bars. gTrade shown as separate internal funding loop.
+**Visual:** Revenue streams as branded bars. gTrade shown as separate internal funding loop with gold accent.
 
 ---
 
 ## Slide 7 — Traction
 
-### Early stage. Real infrastructure. Honest metrics.
+### Early stage. Real infrastructure. No fiction.
 
-**Live & operational:**
-- Production infrastructure: VPS, Docker, Python 3.11, deployment pipeline
-- AI integrations: Claude, Grok, Perplexity — all active in CoreeyAI
-- gTrade: Autonomous trading bot — live and self-funding development
-- Perplexity Orb: Agentic session management — deployed
-- Documentation: 7-brand architecture fully documented, public on GitHub
+**Live and running:**
+- Sovereign VPS — Docker, Python 3.11, deployment pipeline operational
+- CoreeyAI — Claude, Grok, Perplexity integrations active
+- gTrade — autonomous trading bot, live, self-funding development
+- Perplexity Orb — agentic session management deployed
+- ZYNTHIO_MASTER_DOCS — 7-brand architecture documented, public on GitHub
 
-**Filed & in process:**
-- SongPal trademark: IPONZ #1318588 — filed, awaiting examination
+**Filed and in process:**
+- SongPal trademark: IPONZ #1318588 — awaiting examination
 - ZYNTHIO LIMITED: NZ Companies Office #15436626 — incorporating May 2026
 - Domain: zynthio.ai — active
 
 **In development:**
-- SongPal MVP — beta target Q2–Q3 2026
+- SongPal MVP (Next.js) — beta target Q2–Q3 2026
 - MOSOKO curriculum — first cohort Q3 2026
-- 2 original tracks written (SIGNAL 336, THE MIRROR ASKED A QUESTION)
+- 2 original DJ Zynrose tracks written, 4-platform deployment pending
 - 19 multilingual avatar scripts across 6 languages
 
-**What we don't have yet:** Paying customers, external funding, a team beyond the founder, streaming presence. We're pre-revenue and we're honest about it.
+**What we don't have yet:** Paying customers. External funding. A team beyond the founder. Streaming presence. We're pre-revenue and we say so upfront.
 
-**Visual:** Timeline with checkmarks (done) and open circles (in progress). Clean, no false metrics.
+**Visual:** Timeline with checkmarks (done) and open circles (in progress). Honest. Clean.
 
 ---
 
 ## Slide 8 — Competitive Landscape
 
-### No one else offers the full stack.
+### Nobody else offers the full stack.
 
-| | Suno/Udio | Splice | Berklee Online | LANDR | **Zynthio** |
-|---|:-:|:-:|:-:|:-:|:-:|
-| AI music production | Yes | No | No | Partial | **Yes** |
-| Education platform | No | No | Yes | No | **Yes** |
-| IP / legal protection | No | No | No | No | **Yes** |
-| Artist proof-of-concept | No | No | No | No | **Yes** |
-| Autonomous funding | No | No | No | No | **Yes** |
-| Creator owns 100% | Varies | Yes | N/A | Yes | **Yes** |
-| Multi-model AI | No | No | No | No | **Yes** |
+| Capability | Suno/Udio | Splice | Berklee | LANDR | Signal Bots | **Zynthio** |
+|---|:-:|:-:|:-:|:-:|:-:|:-:|
+| AI music production | Yes | No | No | Partial | No | **Yes** |
+| Multi-model AI orchestration | No | No | No | No | No | **Yes** |
+| Education platform | No | No | Yes | No | No | **Yes** |
+| IP / legal protection | No | No | No | No | No | **Yes** |
+| Autonomous trading | No | No | No | No | Subscription | **Competition** |
+| Artist proof of concept | No | No | No | No | No | **Yes** |
+| Creator owns 100% | Varies | Yes | N/A | Yes | N/A | **Yes** |
+| Open architecture | No | No | No | No | No | **Yes** |
 
-**The moat:** Vertical integration. Every new user feeds the entire ecosystem — creating on SongPal, learning through MOSOKO, protected by KERVALON, inspired by DJ Zynrose.
+**The moat:** Vertical integration + competition model + open architecture. Every new user feeds the entire ecosystem. Every brand reinforces every other.
 
-**Visual:** Feature matrix with checkmarks. Competitors greyed out where they don't deliver. Zynthio column in Signal Gold.
+**Visual:** Feature matrix. Competitors greyed out. Zynthio column in Signal Gold.
 
 ---
 
 ## Slide 9 — The Founder
 
-### Corey McIvor — Builder, producer, founder.
+### Corey McIvor — The engineer is the founder.
 
 - **Citizenship:** NZ/AU dual citizen
 - **Location:** Managua, Nicaragua (operating globally)
-- **Technical:** Full-stack developer, AI engineer — Python, Docker, multi-model AI orchestration
+- **Technical:** Full-stack developer, AI engineer — Next.js, Python, Docker, multi-model orchestration
 - **Creative:** Independent music producer (DJ Zynrose) — electronic / experimental / ambient
-- **Built:** The entire Zynthio stack — architecture, code, brand, legal filings, music, and documentation. Solo.
+- **Built:** The entire stack. Solo. Architecture, code, AI integrations, trading engine, brand, legal filings, music, and documentation.
 
 **Why this founder:**
-- The engineer *is* the artist. The person building the tools is also the person using them to create music. This is not theoretical — it's tested daily.
-- NZ/AU citizen — qualified NZ company director, aligned with NZ tech ecosystem
-- Resourceful: bootstrapped with ~NZD $300–500/month burn, self-funded via gTrade
+- The engineer *is* the artist. The person building the tools uses them daily to create music. This is not theoretical.
+- Built and deployed an autonomous trading bot that self-funds development. That's resourcefulness, not just ambition.
+- NZ/AU citizen, qualified NZ company director, operating globally from day one.
+- Monthly burn: ~NZD $300–500. This founder doesn't need your money to survive. He needs it to scale.
 
-**Visual:** Founder photo (if available). GitHub contribution graph. Clean, minimal layout.
+**Visual:** GitHub contribution graph. Clean, minimal.
 
 ---
 
 ## Slide 10 — The Ask
 
-### What we need. What we'll do with it.
+### What we need. What you get.
 
 **Seed raise:** NZD $150,000–250,000
 
 | Allocation | % | Amount (NZD $200K) |
 |-----------|---|-------------------|
-| SongPal development | 35% | $70,000 |
+| SongPal development (Next.js MVP) | 35% | $70,000 |
 | MOSOKO curriculum | 20% | $40,000 |
 | Marketing & community | 20% | $40,000 |
 | Legal, IP, compliance | 10% | $20,000 |
 | Infrastructure & tools | 5% | $10,000 |
 | Operating reserve | 10% | $20,000 |
 
-**12-month targets post-funding:**
+**12-month milestones post-funding:**
 - SongPal: 100+ paying users, beta → paid launch
 - MOSOKO: 100 enrolled students across 2+ cohorts
 - CoreeyAI: First B2B API client
+- gTrade: Published performance metrics, competition model validated at scale
 - DJ Zynrose: Tracks deployed, 1,000+ streams
 - ZYNTHIO LIMITED: Incorporated, operating, first annual return filed
 
-**3-year revenue trajectory:** ~NZD $1.3M cumulative
+**3-year cumulative revenue:** ~NZD $1.3M
 
-**Closing line:** *"We're not pitching a feature. We're pitching a new creative infrastructure for the post-AI world. One stack. Seven brands. No filler. All signal."*
+**Closing line:** *"We're not pitching a feature. We're pitching sovereign infrastructure for the post-AI world. The competition model, not the subscription model. Open architecture, not vendor lock-in. One stack. Seven brands. No filler. All signal."*
 
-**Visual:** Use-of-funds pie chart. 12-month milestone timeline. zynthio.ai + contact info.
+**Visual:** Use-of-funds pie chart. 12-month milestone timeline. zynthio.ai + contact.
 
 ---
 
@@ -236,15 +246,18 @@ ZYNTHIO (Parent)
 | Body | Inter, 400 weight |
 | Data / code | JetBrains Mono, 400 weight |
 | Slide ratio | 16:9 |
-| Max words per slide | 80–100 (audiences read less than you think) |
+| Max words per slide | 80–100 |
 
 ---
 
 ## Delivery Notes
 
 - **Time:** 5–7 minutes for full deck. 3 minutes if trimmed to slides 1–4, 7, 10.
-- **Tone:** Bold but honest. Confident, not hype. Acknowledge early stage — then show what's real.
-- **Adaptation:** For music competitions, lead with slides 3–4 (SongPal + DJ Zynrose). For AI competitions, lead with slide 4 (CoreeyAI architecture). For startup competitions, lead with slides 5–6 (market + business model).
+- **Tone:** Bold but honest. Confident, not hype. Acknowledge early stage — then show what's running.
+- **For fintech competitions:** Lead with slides 2, 4 (gTrade competition model), 5 (market), 8 (vs signal bots). Emphasise performance-based trading, risk management, multi-model orchestration.
+- **For AI competitions:** Lead with slides 3–4 (CoreeyAI architecture, multi-model routing). Show the prompt-to-output pipeline.
+- **For music competitions:** Lead with slides 3–4 (SongPal + DJ Zynrose). Play music. Show MOSOKO.
+- **For startup competitions:** Lead with slides 5–6 (market + business model). Close hard on the ask.
 - **Demo integration:** If live demo is allowed, insert between slides 7 and 8. See [DEMO_SCRIPT.md](DEMO_SCRIPT.md).
 
 ---

--- a/PRESS_KIT.md
+++ b/PRESS_KIT.md
@@ -11,29 +11,27 @@
 
 ### The Short Version (50 words)
 
-Zynthio is a sovereign AI-powered creative ecosystem built by Corey McIvor — a NZ/AU developer, producer, and AI engineer operating from Nicaragua. Seven interconnected brands deliver AI music production, education, IP protection, and autonomous trading infrastructure. One founder. One stack. Incorporating in New Zealand, May 2026.
+Zynthio is a sovereign AI ecosystem built by Corey McIvor — a NZ/AU developer, producer, and AI engineer. Seven interconnected brands deliver multi-model AI orchestration, autonomous algorithmic trading, AI music production, creator education, and IP protection. One founder. One stack. Incorporating in New Zealand, May 2026. No filler. All signal.
 
 ### The Medium Version (150 words)
 
-Independent creators are fragmented across broken tooling — expensive AI platforms that extract value, education systems disconnected from real tools, and legal infrastructure they can't access. Zynthio solves this with a vertically integrated creative-technology ecosystem.
+Independent traders and creators face the same structural problem: the AI tools are getting better, but the systems around them are getting worse. Retail traders battle black-box algorithms on expensive subscriptions. Music creators use platforms that capture their value. Education hasn't caught up. Legal protection is inaccessible.
 
-Seven brands operate as one system: SongPal (AI music production, trademark filed), CoreeyAI (multi-model AI orchestration), MOSOKO (creator education), DJ Zynrose (artist proof of concept), COREINTENT (dev studio and autonomous trading), KERVALON (legal and IP protection), and ZYNTHIO (parent company, incorporating in New Zealand).
+Zynthio solves this with a vertically integrated, sovereign AI ecosystem. Seven brands operate as one system: CoreeyAI (multi-model AI orchestration across Claude, Grok, Perplexity, and Suno), COREINTENT (development studio and gTrade autonomous trading), SongPal (AI music production — trademark filed at IPONZ), MOSOKO (creator education), DJ Zynrose (artist proof of concept), KERVALON (legal and IP protection), and ZYNTHIO (parent company, incorporating in New Zealand).
 
-The founder, Corey McIvor, built the entire stack — the AI integrations, the production infrastructure, the brand architecture, the music, and the legal filings. He is both the engineer and the artist. Every track released under DJ Zynrose is made using the same tools Zynthio builds for everyone.
-
-Zynthio is not a product. It is infrastructure for creative sovereignty.
+The founder, Corey McIvor, built every layer — the AI orchestration, the trading engine, the production platform, the brand architecture, the music, and the legal filings. The engineer is the founder. The artist is the proof of concept.
 
 ### The Full Version (300 words)
 
-The post-AI creative economy has a structural problem: the tools are getting better, but the infrastructure around them is getting worse. Independent creators can now produce studio-quality music in minutes — but the platforms capturing that value give nothing back. Education hasn't caught up. Legal protection remains inaccessible. The full pipeline from creation to ownership is broken.
+The post-AI economy has a structural problem that cuts across trading and creative industries alike: sophisticated AI orchestration is available to institutions, but the infrastructure serving independents is extractive, opaque, and fragmented. Retail traders pay for subscription signals they can't audit. Music creators produce on platforms that own their output. Education is disconnected from the tools reshaping both industries.
 
-Zynthio is the answer to that structural problem. Founded by Corey McIvor — a New Zealand/Australian dual citizen, full-stack developer, AI engineer, and working music producer — Zynthio is a vertically integrated creative-technology ecosystem built from the ground up.
+Zynthio is the sovereign answer. Founded by Corey McIvor — a New Zealand/Australian dual citizen, full-stack developer, AI systems architect, and working music producer — Zynthio is a vertically integrated ecosystem built from the ground up to serve independents.
 
-The architecture is deliberate. SongPal is the flagship AI music production platform, with a trademark filed at IPONZ (#1318588). CoreeyAI is the intelligence layer — not a wrapper around one API, but a purpose-built orchestration system routing tasks across Claude, Grok, Perplexity, and Suno. MOSOKO teaches independent creators how to use the full stack, with cohort programmes and self-paced modules launching in 2026. KERVALON handles IP protection, trademark filings, and compliance. COREINTENT is the engineering arm, also operating gTrade — an autonomous, risk-managed trading bot that self-funds development without external dependency. And DJ Zynrose is Corey's artist persona: the living proof that the stack works, producing original electronic music using the same tools Zynthio is building for everyone.
+The engineering is deliberate. CoreeyAI is the multi-model AI orchestration layer — not a wrapper, but a purpose-built routing system that sends tasks to Claude for reasoning, Grok for real-time market analysis, Perplexity for research, and Suno for audio generation. COREINTENT, the development studio, also operates gTrade — an autonomous, risk-managed trading bot that self-funds the ecosystem through a competition-based model. No signal-selling. No subscriptions. Performance is the product.
 
-The company is incorporating as ZYNTHIO LIMITED in New Zealand in May 2026. The infrastructure is live — Docker, Python 3.11, multi-model AI integrations, and a public documentation repository on GitHub. The team is the founder. The burn rate is under NZD $500/month. The ambition is global.
+SongPal is the flagship AI music production platform, with a trademark filed at IPONZ (#1318588) and a Next.js MVP in development. MOSOKO teaches independent creators to use the full stack. KERVALON handles IP protection and compliance. And DJ Zynrose — Corey's artist persona — produces original electronic music using the same tools, proving the stack works by using it publicly.
 
-Zynthio is targeting a ~$9.5B addressable market across music production software, AI music generation, and online education. The seed raise is NZD $150–250K. The moat is clear: no competitor combines AI production, education, IP infrastructure, and an artist persona under one sovereign architecture.
+The company is incorporating as ZYNTHIO LIMITED in New Zealand in May 2026. The infrastructure is live — Docker, Python 3.11, multi-model AI integrations, and a public documentation repository on GitHub. The team is the founder. The burn rate is under NZD $500/month. The architecture is open. The ambition is global.
 
 No filler. All signal.
 
@@ -43,23 +41,23 @@ No filler. All signal.
 
 ### Short Bio (50 words)
 
-Corey McIvor is a NZ/AU dual citizen, full-stack developer, AI engineer, and independent music producer. He founded Zynthio — a seven-brand creative-technology ecosystem — and built every layer: the code, the AI integrations, the brand architecture, the music, and the legal filings. Based in Managua, Nicaragua.
+Corey McIvor is a NZ/AU dual citizen, full-stack developer, AI engineer, and independent music producer. He founded Zynthio — a seven-brand sovereign AI ecosystem — and built every layer: the multi-model AI orchestration, the autonomous trading engine, the music platform, the brand architecture, and the legal filings. Based in Managua, Nicaragua.
 
 ### Medium Bio (100 words)
 
-Corey McIvor is the founder of Zynthio, a sovereign AI-powered creative ecosystem incorporating in New Zealand. A dual NZ/AU citizen based in Managua, Nicaragua, Corey is a full-stack developer and AI engineer who built the entire Zynthio stack solo — from multi-model AI orchestration (CoreeyAI) to a trademark-filed music production platform (SongPal) to an autonomous trading bot (gTrade) that self-funds development.
+Corey McIvor is the founder of Zynthio, a sovereign AI ecosystem incorporating in New Zealand. A dual NZ/AU citizen based in Managua, Nicaragua, Corey is a full-stack developer and AI engineer who built the entire stack solo — from multi-model AI orchestration (CoreeyAI) to a trademark-filed music production platform (SongPal) to an autonomous trading bot (gTrade) that self-funds development through a competition-based model.
 
-Under his artist name DJ Zynrose, Corey produces original electronic music using the same tools he builds — making him both the engineer and the proof of concept. His work spans AI, music production, education, and IP infrastructure.
+Under his artist name DJ Zynrose, Corey produces original electronic music using the same tools he builds — making him both the engineer and the living proof of concept. His work spans AI orchestration, algorithmic trading, music production, education, and IP infrastructure.
 
 ### Extended Bio (200 words)
 
-Corey McIvor is the founder of Zynthio — a vertically integrated, AI-powered creative-technology ecosystem incorporating in New Zealand in May 2026. A New Zealand/Australian dual citizen operating from Managua, Nicaragua, Corey occupies a rare intersection: full-stack software engineer, AI systems architect, and working independent music producer.
+Corey McIvor is the founder of Zynthio — a vertically integrated, sovereign AI ecosystem incorporating in New Zealand in May 2026. A New Zealand/Australian dual citizen operating from Managua, Nicaragua, Corey occupies a rare intersection: full-stack software engineer, AI systems architect, algorithmic trading developer, and working independent music producer.
 
-Corey built the entire Zynthio stack from scratch. CoreeyAI, the intelligence layer, orchestrates tasks across Claude (Anthropic), Grok (xAI), Perplexity, and Suno — not as an API wrapper, but as a purpose-built routing engine. SongPal, the flagship AI music production platform, has a trademark filed with IPONZ (#1318588). COREINTENT, the development studio, also operates gTrade — an autonomous, risk-managed trading bot that self-funds the ecosystem without external capital dependency.
+Corey built the entire Zynthio stack from scratch. CoreeyAI orchestrates tasks across Claude (Anthropic), Grok (xAI), Perplexity, and Suno — routing to the right model for each job. COREINTENT, the development studio, operates gTrade — an autonomous, risk-managed trading bot running a competition-based model that self-funds the ecosystem. SongPal, the AI music production platform built on Next.js, has a trademark filed with IPONZ (#1318588). The frontend and backend are engineered with Next.js, Python 3.11, and Docker on sovereign infrastructure.
 
-Under his artist name DJ Zynrose, Corey produces original electronic and experimental music — including upcoming tracks *SIGNAL 336* and *THE MIRROR ASKED A QUESTION* — using the same tools he's building for everyone. This makes him both the creator of the technology and its most authentic user.
+Under his artist name DJ Zynrose, Corey produces original electronic and experimental music — including tracks *SIGNAL 336* and *THE MIRROR ASKED A QUESTION* — using the same tools he builds for everyone. The artist is the test case. The engineer is the founder.
 
-MOSOKO, Zynthio's education brand, will teach independent creators how to use the full stack. KERVALON, the legal arm, protects every asset the ecosystem produces. Seven brands, one founder, one doctrine: *No filler. All signal.*
+MOSOKO teaches independent creators to use the full stack. KERVALON protects every asset the ecosystem produces. Seven brands, one founder, one doctrine: *No filler. All signal.*
 
 ---
 
@@ -69,27 +67,33 @@ MOSOKO, Zynthio's education brand, will teach independent creators how to use th
 
 ### On the vision:
 
-> "We're not pitching a feature. We're pitching a new creative infrastructure for the post-AI world."
+> "We're not pitching a feature. We're pitching sovereign infrastructure for the post-AI world."
 
-> "Zynthio is not a product. It is a stack. Build, think, create, teach, protect, scale — all under one roof."
+> "Zynthio is not a product. It's a stack. Build, think, create, teach, protect, scale — all under one roof."
+
+### On the competition model:
+
+> "We don't sell signals. We don't charge subscriptions for algorithms you can't see. We compete in the market. Performance is the product."
+
+> "Most startups burn cash while they build. gTrade funds our development autonomously. That's sovereignty in practice."
 
 ### On creative sovereignty:
 
-> "Independent creators can now produce at scale. But they can't protect at scale. That's the gap we close."
+> "Independent creators can produce at scale. But they can't protect at scale. That's the gap we close."
 
-> "The tools are getting better, but the infrastructure around them is getting worse. Zynthio fixes the infrastructure."
+> "The tools are getting smarter, but the systems around them are getting worse. Zynthio fixes the systems."
 
 ### On being a solo founder:
 
 > "This is not a pitch deck looking for an engineer. The engineer is the founder."
 
-> "I built every layer — the AI, the code, the brand, the music, and the legal filings. That's not a limitation. That's alignment."
+> "I built every layer — the AI orchestration, the trading engine, the music platform, the brand, and the legal filings. That's not a limitation. That's alignment."
 
-### On the business model:
+### On open architecture:
 
-> "We don't burn cash while we build. gTrade funds our development autonomously. That's sovereignty in practice."
+> "Competition model, not subscription. Open architecture, not vendor lock-in. That's the thesis."
 
-> "The artist is the proof of concept. Every DJ Zynrose track is a live demo of the SongPal stack."
+> "Our documentation is public. Our codebase is MIT-licensed. Transparency is a feature, not a vulnerability."
 
 ### On New Zealand:
 
@@ -147,10 +151,10 @@ MOSOKO, Zynthio's education brand, will teach independent creators how to use th
 | Brand | Tagline |
 |-------|---------|
 | **ZYNTHIO** | *No filler. All signal.* |
-| **SongPal** | *Your sound. Your stack.* |
-| **MOSOKO** | *Make it. Own it. Teach it.* |
 | **COREINTENT** | *Build with intent. Ship with precision.* |
 | **CoreeyAI** | *The intelligence layer of the Zynthio ecosystem.* |
+| **SongPal** | *Your sound. Your stack.* |
+| **MOSOKO** | *Make it. Own it. Teach it.* |
 | **KERVALON** | *The protector of the Zynthio ecosystem.* |
 | **DJ Zynrose** | *The sound of the sovereign stack.* |
 
@@ -166,10 +170,12 @@ MOSOKO, Zynthio's education brand, will teach independent creators how to use th
 | Location | Managua, Nicaragua |
 | Incorporation | ZYNTHIO LIMITED — NZ Companies Office #15436626 |
 | Flagship product | SongPal — AI music production (TM: IPONZ #1318588) |
+| Tech stack | Next.js, Python 3.11, Docker, multi-model AI |
 | Brands | 7 interconnected brands |
 | AI models | Claude, Grok, Perplexity, Suno |
-| TAM | ~$9.5B |
-| Funding stage | Pre-seed (bootstrapped) |
+| Trading engine | gTrade — autonomous, competition-based, risk-managed |
+| TAM | ~$9.5B (creative) / ~$25B+ (incl. trading) |
+| Funding stage | Pre-seed (bootstrapped + gTrade self-funding) |
 | Seed target | NZD $150,000–250,000 |
 | Monthly burn | ~NZD $280–480 |
 | Domain | zynthio.ai |
@@ -185,10 +191,12 @@ MOSOKO, Zynthio's education brand, will teach independent creators how to use th
 | Asset | Status | Location |
 |-------|--------|----------|
 | ZYNTHIO primary wordmark | Pending | *(add URL)* |
+| COREINTENT wordmark | Pending | *(add URL)* |
 | SongPal primary wordmark | Pending | *(add URL)* |
 | DJ Zynrose artist logo | Pending | *(add URL)* |
 | Founder headshot | Pending | *(add URL)* |
 | Ecosystem architecture diagram | Available | [ECOSYSTEM_MAP.md](ECOSYSTEM_MAP.md) |
+| Brand colour swatches | Available | See Brand Colours section above |
 
 ---
 
@@ -203,13 +211,16 @@ Domain: [zynthio.ai](https://zynthio.ai)
 
 ## Usage Guidelines
 
-1. Use "Zynthio" (capital Z) in all editorial contexts — not "ZYNTHIO" unless in a legal or branding context
-2. Use "SongPal" as two words with capitals — not "Songpal" or "Song Pal"
+1. Use "Zynthio" (capital Z) in editorial contexts — "ZYNTHIO" in legal/branding contexts
+2. Use "SongPal" as two words — not "Songpal" or "Song Pal"
 3. Include TM symbol (SongPal™) in first mention within any document
-4. DJ Zynrose is the artist name — refer to the person as "Corey McIvor" in non-artist contexts
-5. Signal Gold (#C9A84C) should be used sparingly — it is an accent, not a fill colour
-6. All brand assets are copyright ZYNTHIO / Corey McIvor unless otherwise stated
-7. Codebase is MIT-licensed — brand assets are not
+4. "CoreIntent" or "COREINTENT" — both acceptable depending on context
+5. DJ Zynrose is the artist name — "Corey McIvor" for non-artist contexts
+6. Signal Gold (#C9A84C) is an accent, not a fill — use sparingly
+7. All brand assets are copyright ZYNTHIO / Corey McIvor
+8. Codebase is MIT-licensed — brand assets are not
+9. "Competition model" not "competitive model" when describing gTrade's approach
+10. "Sovereign" not "decentralised" — Zynthio is self-owned, not blockchain-based
 
 ---
 


### PR DESCRIPTION
## Summary

- **COMPETITION_PORTFOLIO.md** — Rewritten to lead with AI trading problem (opaque, expensive, gatekept), position CoreIntent's competition model vs subscription, add Next.js to tech architecture, expand TAM to $25B+ including retail trading and AI-assisted investing
- **PITCH_DECK_OUTLINE.md** — All 10 slides updated with fintech/trading angle, competition model framing, and per-competition delivery notes (fintech, AI, music, startup)
- **DEMO_SCRIPT.md** — 3-minute demo restructured with gTrade competition model segment, multi-model orchestration demo, and adaptation notes for fintech competitions
- **PRESS_KIT.md** — Brand story rewritten with trading + creative dual narrative, new key quotes on competition model and open architecture, added usage guideline for "sovereign" vs "decentralised"
- **AWARDS_TRACKER.md** — Expanded from 17 to 22 tracked competitions: added Antler Residency, Techstars Music, Microsoft for Startups, NZTA Awards, Y Combinator

## Test plan

- [ ] Verify all internal links between documents resolve correctly
- [ ] Confirm no contradictions with FINANCIAL_MODEL.md, NZ_COMPLIANCE.md, or ECOSYSTEM_MAP.md
- [ ] Review founder bio consistency across PRESS_KIT.md and COMPETITION_PORTFOLIO.md
- [ ] Check all competition URLs are plausible (exact URLs should be verified before submission)

https://claude.ai/code/session_01AHoe7VxVqtXqcdDtJo1WCb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; main risk is messaging/consistency errors across linked materials and competition timelines.
> 
> **Overview**
> Repositions the competition narrative across `COMPETITION_PORTFOLIO.md`, `PITCH_DECK_OUTLINE.md`, `DEMO_SCRIPT.md`, and `PRESS_KIT.md` to lead with **CoreIntent/gTrade’s trading “competition model”** and **multi-model AI orchestration**, expanding market framing (incl. trading) and updating tech stack references (e.g., Next.js) and key talking points.
> 
> Expands `AWARDS_TRACKER.md` from 17 to **22** tracked opportunities, adding region fields, new accelerators/credits (e.g., Antler, Techstars Music, Microsoft for Startups, YC, NZTA Awards), and updating the suggested 2026 application timeline and submission checklists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f5aa5ba5712952c58cdc17dda9a33740f0a8c31. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->