### PR TITLE
docs: align investor pitch TAM with pitch deck

### DIFF
--- a/avatars/scripts/sales/investor-pitch-en.md
+++ b/avatars/scripts/sales/investor-pitch-en.md
@@ -10,11 +10,11 @@ Thank you for your time. Let me tell you why *Zynthio* deserves your attention.
 
 [PAUSE 1s]
 
-The global music production software market is worth 5.9 billion dollars, growing at eight percent year over year. AI music generation is 1.5 billion — growing at *twenty-five percent* annually. Add online music education at 2.1 billion, and you're looking at a total addressable market of roughly *9.5 billion dollars*.
+The combined addressable market across our verticals exceeds *twenty-one billion dollars*. Music production software — 5.9 billion, growing at eight percent. AI music generation — 1.5 billion, growing at *twenty-five percent* annually. Online music education — 2.1 billion. And AI-assisted retail trading — over 12 billion, growing at eighteen percent year over year.
 
 [GESTURE: open hand]
 
-Right now, that market is fragmented. Independent creators stitch together expensive, disconnected tools for production, education, legal protection, and distribution. Nobody offers the full stack.
+Right now, every one of those markets is fragmented. Independent creators stitch together expensive, disconnected tools. Retail traders pay blind subscriptions with no alignment. Nobody offers the full stack.
 
 [PAUSE 0.5s]
 


### PR DESCRIPTION
## Summary

- Updated investor pitch script TAM from $9.5B (music-only) to $21B+ to include AI-assisted retail trading ($12B+), matching PITCH_DECK_OUTLINE.md
- The investor pitch already features gTrade/CoreIntent trading engine, so the TAM should reflect all verticals
- Also updated the market fragmentation language to reference retail traders alongside creators

## Test plan

- [ ] Review investor-pitch-en.md reads naturally as spoken script
- [ ] Verify TAM figures match PITCH_DECK_OUTLINE.md segments
- [ ] Confirm duration estimate (~130s) still holds with updated wording

https://claude.ai/code/session_01FQHXGoS9K9sjB6UiwxckAS

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQHXGoS9K9sjB6UiwxckAS)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only copy updates with no code or behavioral impact.
> 
> **Overview**
> Updates `avatars/scripts/sales/investor-pitch-en.md` to revise TAM messaging from a ~$9.5B music-only figure to a *$21B+* multi-vertical market that explicitly includes AI-assisted retail trading.
> 
> Adjusts the accompanying “fragmented market” narrative to reference both creators and retail traders, aligning the pitch script with the broader verticals described elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adbe31a30652ccf8a9eceb9f9284a8bfd5596092. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->