### PR TITLE
docs: polish competition entry materials for 2026 submissions

### DIFF
--- a/AWARDS_TRACKER.md
+++ b/AWARDS_TRACKER.md
@@ -1,6 +1,6 @@
 # AWARDS TRACKER — Zynthio 2026
 
-![Status](https://img.shields.io/badge/status-active-brightgreen) ![Updated](https://img.shields.io/badge/updated-2026--05--09-blue) ![Year](https://img.shields.io/badge/year-2026-purple) ![Targets](https://img.shields.io/badge/targets-21-orange)
+![Status](https://img.shields.io/badge/status-active-brightgreen) ![Updated](https://img.shields.io/badge/updated-2026--05--11-blue) ![Year](https://img.shields.io/badge/year-2026-purple) ![Targets](https://img.shields.io/badge/targets-25-orange)
 
 > Tracking relevant competitions, awards, grants, and accelerators for Zynthio across AI, fintech, music technology, and startup categories.
 
@@ -12,10 +12,10 @@ Before entering any competition, confirm:
 
 - [ ] ZYNTHIO LIMITED incorporated (deadline **May 12, 2026**)
 - [ ] Founder contact email added to all submission materials
-- [ ] Check eligibility: entity type, jurisdiction, stage, team size
-- [ ] Tailor the ask to what the specific competition offers
-- [ ] Attach financial projections if required ([FINANCIAL_MODEL.md](FINANCIAL_MODEL.md))
-- [ ] Check word/slide/video limits — adapt [COMPETITION_PORTFOLIO.md](COMPETITION_PORTFOLIO.md) accordingly
+- [ ] Eligibility confirmed: entity type, jurisdiction, stage, team size
+- [ ] The ask is tailored to what the competition offers
+- [ ] Financial projections attached if required ([FINANCIAL_MODEL.md](FINANCIAL_MODEL.md))
+- [ ] Word/slide/video limits checked — adapt [COMPETITION_PORTFOLIO.md](COMPETITION_PORTFOLIO.md) accordingly
 
 ---
 
@@ -24,26 +24,31 @@ Before entering any competition, confirm:
 | # | Competition | Category | Status | Deadline | Priority |
 |---|------------|----------|--------|----------|----------|
 | 1 | Callaghan Innovation R&D Grant | AI / R&D | Not started | Rolling | **HIGH** |
-| 2 | Creative HQ Startup Programme | Startup | Not started | TBC (check website) | **HIGH** |
-| 3 | Lightning Lab | SaaS / Deep tech | Not started | TBC (check website) | **HIGH** |
-| 4 | Startmate Accelerator (AU) | SaaS / Consumer | Not started | TBC (check website) | **HIGH** |
-| 5 | SXSW Sydney Startup Competition | Music / Tech | Not started | TBC (typically mid-year) | **HIGH** |
-| 6 | MIDEM Accelerator | Music industry | Not started | TBC (check website) | **HIGH** |
-| 7 | Music Ally LAUNCH | Music tech | Not started | TBC (check website) | **HIGH** |
-| 8 | Antler Residency (AU/NZ) | Startup | Not started | Rolling cohorts | **HIGH** |
-| 9 | Edmund Hillary Fellowship | Global impact | Not started | TBC (check website) | MEDIUM |
-| 10 | NZ Music Commission | Music industry | Not started | Rolling | MEDIUM |
-| 11 | Creative Australia Grants | Arts / Music | Not started | TBC | MEDIUM |
-| 12 | Product Hunt Hackathon | Product / AI | Not started | TBC | MEDIUM |
-| 13 | ITU AI for Good | AI impact | Not started | TBC | MEDIUM |
-| 14 | Techweek NZ | Tech / Startup | Not started | TBC (May–June 2026) | MEDIUM |
-| 15 | NZ Hi-Tech Awards | Tech | Not started | TBC (typically H1) | MEDIUM |
-| 16 | FinTech Australia Awards | Fintech / AI | Not started | TBC (typically H2) | MEDIUM |
-| 17 | NZX Fintech Accelerator | Fintech / Trading | Not started | TBC | MEDIUM |
-| 18 | Seedstars Global | Startup | Not started | Rolling | MEDIUM |
-| 19 | AWS Startup Programme | Cloud / AI | Not started | Rolling | LOW |
-| 20 | Google for Startups | Cloud / AI | Not started | Rolling | LOW |
-| 21 | Anthropic Partner / Builder | AI | Not started | Rolling | LOW |
+| 2 | Creative HQ Startup Programme | Startup | Not started | TBC | **HIGH** |
+| 3 | Lightning Lab | SaaS / Deep tech | Not started | TBC | **HIGH** |
+| 4 | Startmate Accelerator (AU) | SaaS / Consumer | Not started | TBC | **HIGH** |
+| 5 | SXSW Sydney Startup Competition | Music / Tech | Not started | TBC (mid-year) | **HIGH** |
+| 6 | MIDEM Accelerator | Music industry | Not started | TBC | **HIGH** |
+| 7 | Music Ally LAUNCH | Music tech | Not started | TBC | **HIGH** |
+| 8 | Antler Residency (AU/NZ) | Startup | Not started | Rolling | **HIGH** |
+| 9 | Blackbird Giants Programme (AU) | Deep tech | Not started | TBC | **HIGH** |
+| 10 | Edmund Hillary Fellowship | Global impact | Not started | TBC | MEDIUM |
+| 11 | NZ Music Commission | Music industry | Not started | Rolling | MEDIUM |
+| 12 | Creative Australia Grants | Arts / Music | Not started | TBC | MEDIUM |
+| 13 | Product Hunt Hackathon | Product / AI | Not started | TBC | MEDIUM |
+| 14 | ITU AI for Good | AI impact | Not started | TBC | MEDIUM |
+| 15 | Techweek NZ | Tech / Startup | Not started | May–Jun 2026 | MEDIUM |
+| 16 | NZ Hi-Tech Awards | Tech | Not started | TBC (H1) | MEDIUM |
+| 17 | FinTech Australia Awards | Fintech / AI | Not started | TBC (H2) | MEDIUM |
+| 18 | NZX Fintech Accelerator | Fintech / Trading | Not started | TBC | MEDIUM |
+| 19 | Seedstars Global | Startup | Not started | Rolling | MEDIUM |
+| 20 | Web Summit PITCH | Startup / AI | Not started | TBC (H2) | MEDIUM |
+| 21 | Slush 100 Pitching Competition | Startup / AI | Not started | TBC (H2) | MEDIUM |
+| 22 | Abbey Road Red (London) | Music tech | Not started | Rolling | MEDIUM |
+| 23 | Techstars Music (AU/Global) | Music / Tech | Not started | TBC | MEDIUM |
+| 24 | AWS Startup Programme | Cloud / AI | Not started | Rolling | LOW |
+| 25 | Google for Startups | Cloud / AI | Not started | Rolling | LOW |
+| 26 | Anthropic Partner / Builder | AI | Not started | Rolling | LOW |
 
 ---
 
@@ -70,10 +75,10 @@ Before entering any competition, confirm:
 |-------|--------|
 | Organiser | Creative HQ (Wellington) |
 | Category | Tech startup accelerator |
-| Fit | **HIGH** — strong creative-tech mandate; Zynthio's music + AI stack is a natural fit |
+| Fit | **HIGH** — strong creative-tech mandate; music + AI stack is a natural fit |
 | What they offer | Accelerator programme, mentorship, workspace, investor introductions |
 | Eligibility | Early-stage NZ-connected startups |
-| Deadline | Check website — typically cohort-based with application rounds |
+| Deadline | Cohort-based — check website |
 | Zynthio angle | SongPal as flagship product, sovereign creative stack narrative, CoreIntent self-funding model |
 | URL | [creativehq.co.nz](https://www.creativehq.co.nz) |
 | Status | **Not started** |
@@ -84,11 +89,11 @@ Before entering any competition, confirm:
 |-------|--------|
 | Organiser | Lightning Lab / Callaghan Innovation |
 | Category | Deep tech, SaaS |
-| Fit | **HIGH** — SongPal SaaS angle; NZ accelerator with strong tech focus |
+| Fit | **HIGH** — SongPal SaaS angle; strong NZ tech accelerator |
 | What they offer | Accelerator programme, seed investment, mentorship |
 | Eligibility | NZ-based or NZ-connected tech startups |
-| Deadline | Check website — cohort applications |
-| Zynthio angle | SongPal SaaS model, CoreeyAI B2B API, multi-model AI architecture, gTrade as unique self-funding angle |
+| Deadline | Cohort-based — check website |
+| Zynthio angle | SongPal SaaS model, CoreeyAI B2B API, multi-model architecture, gTrade self-funding |
 | URL | [lightninglab.co.nz](https://www.lightninglab.co.nz) |
 | Status | **Not started** |
 
@@ -98,11 +103,11 @@ Before entering any competition, confirm:
 |-------|--------|
 | Organiser | NZ Music Commission |
 | Category | Music industry development |
-| Fit | MEDIUM — DJ Zynrose artist angle + MOSOKO education alignment |
+| Fit | MEDIUM — DJ Zynrose artist angle + MOSOKO education |
 | What they offer | Grants, industry connections, export support |
 | Eligibility | NZ music artists and music businesses |
 | Deadline | Rolling / programme-specific |
-| Zynthio angle | DJ Zynrose as NZ artist using AI production tools; MOSOKO as NZ music education platform; SongPal as NZ-built tool |
+| Zynthio angle | DJ Zynrose as NZ artist using AI tools; MOSOKO as NZ music education; SongPal as NZ-built platform |
 | URL | [nzmusic.org.nz](https://www.nzmusic.org.nz) |
 | Status | **Not started** |
 
@@ -112,11 +117,11 @@ Before entering any competition, confirm:
 |-------|--------|
 | Organiser | EHF |
 | Category | Global impact entrepreneurs |
-| Fit | MEDIUM — founder narrative (sovereign creative stack for global independent artists) |
+| Fit | MEDIUM — sovereign creative stack for global independent artists |
 | What they offer | Fellowship, NZ Global Impact Visa, community, mentorship |
 | Eligibility | Entrepreneurs with global impact potential; NZ connection |
-| Deadline | Check website — rolling/cohort |
-| Zynthio angle | Sovereign creative infrastructure for independent artists worldwide; NZ-based company with global ambition; democratising AI tools |
+| Deadline | Rolling/cohort — check website |
+| Zynthio angle | Democratising AI tools for independent creators worldwide; NZ company with global ambition |
 | URL | [ehf.org](https://www.ehf.org) |
 | Status | **Not started** |
 
@@ -126,11 +131,11 @@ Before entering any competition, confirm:
 |-------|--------|
 | Organiser | NZ Tech |
 | Category | Technology showcase |
-| Fit | MEDIUM — startup showcase and pitch opportunities |
-| What they offer | Visibility, pitch competition, networking |
+| Fit | MEDIUM — pitch competition and visibility |
+| What they offer | Showcase, pitch opportunities, networking |
 | Eligibility | NZ tech companies |
-| Deadline | Typically May–June 2026 |
-| Zynthio angle | AI music production + sovereign architecture + self-funding trading model |
+| Deadline | May–June 2026 |
+| Zynthio angle | AI music production + sovereign architecture + self-funding |
 | Status | **Not started** |
 
 ### NZ Hi-Tech Awards
@@ -139,11 +144,11 @@ Before entering any competition, confirm:
 |-------|--------|
 | Organiser | NZ Hi-Tech Trust |
 | Category | Technology awards |
-| Fit | MEDIUM — early-stage / emerging company category |
+| Fit | MEDIUM — emerging company category |
 | What they offer | Recognition, media coverage, investor visibility |
 | Eligibility | NZ tech companies |
 | Deadline | Typically H1 — check website |
-| Zynthio angle | Most innovative emerging tech company; AI + music + fintech intersection |
+| Zynthio angle | Most innovative emerging tech; AI + music + fintech intersection |
 | Status | **Not started** |
 
 ---
@@ -156,11 +161,11 @@ Before entering any competition, confirm:
 |-------|--------|
 | Organiser | SXSW Sydney |
 | Category | Music / Technology crossover |
-| Fit | **HIGH** — music-tech startup competition; SongPal + DJ Zynrose angle is strong |
+| Fit | **HIGH** — music-tech startup competition; SongPal + DJ Zynrose is strong |
 | What they offer | Showcase, industry exposure, investor access, media coverage |
 | Eligibility | Startups with music/tech/creative focus |
 | Deadline | Typically mid-year — check website |
-| Zynthio angle | SongPal AI music production, DJ Zynrose as performing proof of concept, CoreIntent self-funding model |
+| Zynthio angle | SongPal AI music, DJ Zynrose performing proof of concept, CoreIntent self-funding |
 | URL | [sxswsydney.com](https://www.sxswsydney.com) |
 | Status | **Not started** |
 
@@ -170,11 +175,11 @@ Before entering any competition, confirm:
 |-------|--------|
 | Organiser | Startmate |
 | Category | SaaS, consumer tech |
-| Fit | **HIGH** — AU/NZ accelerator; strong founder-market fit, SaaS model |
+| Fit | **HIGH** — AU/NZ accelerator; strong founder-market fit |
 | What they offer | Seed investment (~AUD $120K), mentorship, network |
-| Eligibility | Early-stage startups, AU/NZ founders welcome |
+| Eligibility | Early-stage startups, AU/NZ founders |
 | Deadline | Cohort-based — check website |
-| Zynthio angle | SongPal SaaS, CoreeyAI API licensing, multi-brand architecture, gTrade unique narrative |
+| Zynthio angle | SongPal SaaS, CoreeyAI licensing, multi-brand architecture, gTrade unique narrative |
 | URL | [startmate.com](https://www.startmate.com) |
 | Status | **Not started** |
 
@@ -184,25 +189,39 @@ Before entering any competition, confirm:
 |-------|--------|
 | Organiser | Antler |
 | Category | Pre-seed / startup builder |
-| Fit | **HIGH** — pre-seed stage, strong founder-first approach |
-| What they offer | AUD $100–250K investment, 6-month residency, mentorship network |
-| Eligibility | Founders building tech startups in AU/NZ region |
-| Deadline | Rolling cohorts — multiple per year |
-| Zynthio angle | Solo technical founder with live infrastructure, clear market, unique self-funding mechanism |
+| Fit | **HIGH** — pre-seed stage, founder-first approach |
+| What they offer | AUD $100–250K investment, 6-month residency, mentorship |
+| Eligibility | Founders building tech startups in AU/NZ |
+| Deadline | Rolling cohorts |
+| Zynthio angle | Solo technical founder with live infrastructure, clear market, unique self-funding |
 | URL | [antler.co](https://www.antler.co) |
+| Status | **Not started** |
+
+### Blackbird Giants Programme
+
+| Field | Detail |
+|-------|--------|
+| Organiser | Blackbird Ventures |
+| Category | Deep tech / ambitious startups |
+| Fit | **HIGH** — Blackbird backs ambitious ANZ founders; self-funding narrative is compelling |
+| What they offer | Investment, mentorship, community of 200+ portfolio companies |
+| Eligibility | AU/NZ startups or founders |
+| Deadline | Rolling — check website |
+| Zynthio angle | Sovereign AI ecosystem, competition-based self-funding, NZ/AU founder building globally from Nicaragua |
+| URL | [blackbird.vc](https://www.blackbird.vc) |
 | Status | **Not started** |
 
 ### Creative Australia Grants
 
 | Field | Detail |
 |-------|--------|
-| Organiser | Creative Australia (formerly Australia Council for the Arts) |
+| Organiser | Creative Australia |
 | Category | Arts, music, creative industries |
-| Fit | MEDIUM — MOSOKO education + DJ Zynrose artist angle |
+| Fit | MEDIUM — MOSOKO education + DJ Zynrose artist |
 | What they offer | Project grants for arts and creative activity |
-| Eligibility | Australian citizens and permanent residents (Corey qualifies as AU citizen) |
+| Eligibility | Australian citizens (Corey qualifies) |
 | Deadline | Multiple rounds per year |
-| Zynthio angle | MOSOKO as cross-Tasman music education initiative; DJ Zynrose as AU/NZ artist using AI |
+| Zynthio angle | MOSOKO cross-Tasman music education; DJ Zynrose as AU/NZ artist |
 | URL | [creative.gov.au](https://www.creative.gov.au) |
 | Status | **Not started** |
 
@@ -212,11 +231,11 @@ Before entering any competition, confirm:
 |-------|--------|
 | Organiser | FinTech Australia |
 | Category | Fintech / AI trading |
-| Fit | MEDIUM — gTrade autonomous trading bot; competition-based model vs subscription signals |
-| What they offer | Industry recognition, investor introductions, media coverage |
+| Fit | MEDIUM — gTrade autonomous trading; competition model |
+| What they offer | Industry recognition, investor introductions, media |
 | Eligibility | Fintech companies with AU/NZ connection |
-| Deadline | Check website — typically H2 |
-| Zynthio angle | gTrade as open-architecture, competition-based algorithmic trading; self-funding mechanism; NZ/AU founder |
+| Deadline | Typically H2 |
+| Zynthio angle | gTrade open-architecture trading; self-funding; NZ/AU founder |
 | URL | [fintechaustralia.org.au](https://www.fintechaustralia.org.au) |
 | Status | **Not started** |
 
@@ -230,11 +249,11 @@ Before entering any competition, confirm:
 |-------|--------|
 | Organiser | MIDEM (Cannes) |
 | Category | Music industry startup accelerator |
-| Fit | **HIGH** — leading music-tech startup competition globally |
-| What they offer | Showcase at MIDEM, industry introductions, investor access, media |
+| Fit | **HIGH** — leading global music-tech startup competition |
+| What they offer | Showcase at MIDEM, industry introductions, investor access |
 | Eligibility | Music technology startups worldwide |
-| Deadline | Check website — typically early in year |
-| Zynthio angle | SongPal as AI music production platform; full creator stack differentiator; DJ Zynrose live element |
+| Deadline | Typically early year — check website |
+| Zynthio angle | SongPal AI music production; full creator stack; DJ Zynrose live element |
 | URL | [midem.com](https://www.midem.com) |
 | Status | **Not started** |
 
@@ -244,12 +263,68 @@ Before entering any competition, confirm:
 |-------|--------|
 | Organiser | Music Ally |
 | Category | Music technology showcase |
-| Fit | **HIGH** — leading music-tech industry event with startup showcase |
-| What they offer | Showcase, pitch competition, press coverage, industry network |
+| Fit | **HIGH** — leading music-tech event with startup showcase |
+| What they offer | Showcase, pitch competition, press coverage |
 | Eligibility | Music tech startups |
 | Deadline | Check website |
-| Zynthio angle | SongPal AI production, DJ Zynrose proof of concept, sovereign stack, CoreeyAI multi-model |
+| Zynthio angle | SongPal AI production, DJ Zynrose proof of concept, sovereign stack |
 | URL | [musically.com](https://www.musically.com) |
+| Status | **Not started** |
+
+### Abbey Road Red (London)
+
+| Field | Detail |
+|-------|--------|
+| Organiser | Abbey Road Studios |
+| Category | Music technology incubator |
+| Fit | MEDIUM — world's most prestigious music-tech incubator |
+| What they offer | Studio access, mentorship, music industry network, brand credibility |
+| Eligibility | Music tech startups at any stage |
+| Deadline | Rolling applications |
+| Zynthio angle | SongPal as AI music production platform; DJ Zynrose as working artist using the stack |
+| URL | [abbeyroad.com/red](https://www.abbeyroad.com/red) |
+| Status | **Not started** |
+
+### Techstars Music (Global)
+
+| Field | Detail |
+|-------|--------|
+| Organiser | Techstars |
+| Category | Music / entertainment tech |
+| Fit | MEDIUM — music-tech accelerator with global network |
+| What they offer | USD $120K investment, mentorship, Techstars network |
+| Eligibility | Music/entertainment tech startups |
+| Deadline | Cohort-based — check website |
+| Zynthio angle | Full music-tech stack (SongPal + MOSOKO + DJ Zynrose); self-funding model |
+| URL | [techstars.com](https://www.techstars.com) |
+| Status | **Not started** |
+
+### Web Summit PITCH
+
+| Field | Detail |
+|-------|--------|
+| Organiser | Web Summit |
+| Category | Startup pitch competition |
+| Fit | MEDIUM — global visibility at one of the world's largest tech conferences |
+| What they offer | Main-stage pitch, investor meetings, media coverage |
+| Eligibility | Early-stage startups |
+| Deadline | Typically H2 |
+| Zynthio angle | Sovereign AI ecosystem; multi-brand architecture; self-funding |
+| URL | [websummit.com](https://www.websummit.com) |
+| Status | **Not started** |
+
+### Slush 100 Pitching Competition
+
+| Field | Detail |
+|-------|--------|
+| Organiser | Slush (Helsinki) |
+| Category | Startup pitch competition |
+| Fit | MEDIUM — premier European startup event; strong AI/tech audience |
+| What they offer | Main-stage pitch, investor access, global media |
+| Eligibility | Early-stage startups worldwide |
+| Deadline | Typically H2 |
+| Zynthio angle | AI-powered sovereign creative stack; global ambition from NZ |
+| URL | [slush.org](https://www.slush.org) |
 | Status | **Not started** |
 
 ### Seedstars Global Competition
@@ -258,11 +333,11 @@ Before entering any competition, confirm:
 |-------|--------|
 | Organiser | Seedstars |
 | Category | Emerging market startups |
-| Fit | MEDIUM — founder operating from Nicaragua; NZ/AU company targeting global market |
-| What they offer | Investment (up to USD $500K), global showcase, mentorship |
-| Eligibility | Startups from emerging markets or with emerging market focus |
-| Deadline | Rolling — regional events feed into global summit |
-| Zynthio angle | Founder based in Nicaragua, building for global independent creators; NZ-incorporated but globally distributed; unique self-funding model means less capital dependency |
+| Fit | MEDIUM — founder operating from Nicaragua; NZ/AU company targeting globally |
+| What they offer | Investment (up to USD $500K), global showcase |
+| Eligibility | Startups from or serving emerging markets |
+| Deadline | Rolling — regional events |
+| Zynthio angle | Founder in Nicaragua, building for global creators; NZ-incorporated, globally distributed |
 | URL | [seedstars.com](https://www.seedstars.com) |
 | Status | **Not started** |
 
@@ -272,11 +347,11 @@ Before entering any competition, confirm:
 |-------|--------|
 | Organiser | Product Hunt |
 | Category | Product / AI |
-| Fit | MEDIUM — good for SongPal launch visibility and product community |
+| Fit | MEDIUM — SongPal launch visibility |
 | What they offer | Visibility, community, potential featuring |
-| Eligibility | Open — product launch or hackathon entry |
-| Deadline | Various — check website |
-| Zynthio angle | SongPal AI platform launch; CoreeyAI as technical innovation |
+| Eligibility | Open |
+| Deadline | Various |
+| Zynthio angle | SongPal AI platform launch; CoreeyAI technical innovation |
 | Status | **Not started** |
 
 ### AI for Good (ITU)
@@ -285,11 +360,11 @@ Before entering any competition, confirm:
 |-------|--------|
 | Organiser | ITU / United Nations |
 | Category | AI for social impact |
-| Fit | MEDIUM — education + sovereignty angle; MOSOKO democratising access to AI tools for creators |
-| What they offer | Global platform, UN visibility, partnership opportunities |
-| Eligibility | AI projects with social impact dimension |
+| Fit | MEDIUM — MOSOKO education + sovereignty angle |
+| What they offer | Global platform, UN visibility, partnerships |
+| Eligibility | AI projects with social impact |
 | Deadline | Check website |
-| Zynthio angle | MOSOKO education for independent creators; democratising AI music production; creative sovereignty for underserved markets |
+| Zynthio angle | MOSOKO democratising AI tools for creators; creative sovereignty for underserved markets |
 | URL | [aiforgood.itu.int](https://aiforgood.itu.int) |
 | Status | **Not started** |
 
@@ -297,13 +372,13 @@ Before entering any competition, confirm:
 
 | Field | Detail |
 |-------|--------|
-| Organiser | NZX / various partners |
-| Category | Fintech / Trading technology |
-| Fit | MEDIUM — gTrade algorithmic trading; NZ-incorporated company |
+| Organiser | NZX / partners |
+| Category | Fintech / Trading tech |
+| Fit | MEDIUM — gTrade algorithmic trading; NZ company |
 | What they offer | Mentorship, market access, investor network |
 | Eligibility | NZ fintech startups |
-| Deadline | Check website — programme-specific |
-| Zynthio angle | gTrade autonomous trading with open risk architecture; NZ jurisdiction; competition model vs subscription |
+| Deadline | Programme-specific |
+| Zynthio angle | gTrade autonomous trading, open risk architecture, competition model |
 | Status | **Not started** |
 
 ---
@@ -315,9 +390,9 @@ Before entering any competition, confirm:
 | Field | Detail |
 |-------|--------|
 | Organiser | Amazon Web Services |
-| What they offer | AWS credits (up to $100K), technical support, mentorship |
+| What they offer | Up to USD $100K AWS credits, technical support |
 | Eligibility | Early-stage startups |
-| Zynthio angle | Infrastructure credits for SongPal scaling; AI compute for CoreeyAI |
+| Zynthio angle | Infrastructure credits for SongPal; AI compute for CoreeyAI |
 | Status | **Not started** — apply post-incorporation |
 
 ### Google for Startups Cloud Program
@@ -325,9 +400,9 @@ Before entering any competition, confirm:
 | Field | Detail |
 |-------|--------|
 | Organiser | Google Cloud |
-| What they offer | GCP credits (up to $200K), technical mentorship |
+| What they offer | Up to USD $200K GCP credits, mentorship |
 | Eligibility | Early-stage startups |
-| Zynthio angle | Cloud infrastructure for CoreeyAI and SongPal; Vertex AI potential for model fine-tuning |
+| Zynthio angle | Cloud infrastructure for CoreeyAI and SongPal |
 | Status | **Not started** — apply post-incorporation |
 
 ### Anthropic Partner / Builder Programme
@@ -335,9 +410,9 @@ Before entering any competition, confirm:
 | Field | Detail |
 |-------|--------|
 | Organiser | Anthropic |
-| What they offer | API credits, technical support, partnership visibility |
+| What they offer | API credits, technical support, partnership |
 | Eligibility | Companies building on Claude API |
-| Zynthio angle | CoreeyAI is built on Claude as primary reasoning engine; strong product fit; already heavy Claude user |
+| Zynthio angle | CoreeyAI is built on Claude as primary reasoning engine; strong product fit |
 | Status | **Not started** — explore once SongPal MVP is live |
 
 ---
@@ -348,22 +423,22 @@ Before entering any competition, confirm:
 
 | Period | Priority Actions |
 |--------|------------------|
-| **May 2026** | Incorporate. Apply for Callaghan Innovation R&D Grant. Research Creative HQ, Lightning Lab, and Antler deadlines. |
-| **June 2026** | Submit to Callaghan Innovation. Apply to Creative HQ or Lightning Lab (whichever has open cohort). Register for Techweek NZ. Apply to Antler. |
-| **July 2026** | Apply to Startmate (AU). Prepare SXSW Sydney application. Begin Music Ally LAUNCH application. |
-| **August 2026** | Submit SXSW Sydney. Apply to MIDEM Accelerator. Apply for cloud credits (AWS, GCP). Research Seedstars regional events. |
-| **September 2026** | Submit to NZ Music Commission (DJ Zynrose angle). Begin Edmund Hillary Fellowship application. Apply to FinTech Australia Awards (gTrade angle). |
-| **October 2026** | Product Hunt launch for SongPal beta. Apply to ITU AI for Good. Begin NZ Hi-Tech Awards submission. |
-| **November 2026** | Apply to Creative Australia Grants. Prepare Anthropic Builder Programme application. |
-| **December 2026** | Review all outcomes. Plan 2027 competition strategy. Prepare for Series A positioning. |
+| **May 2026** | Incorporate. Apply for Callaghan Innovation R&D Grant. Research Creative HQ, Lightning Lab, Antler, and Blackbird deadlines. |
+| **June 2026** | Submit Callaghan Innovation. Apply to Creative HQ or Lightning Lab. Register for Techweek NZ. Apply to Antler. Research Abbey Road Red. |
+| **July 2026** | Apply to Startmate (AU). Prepare SXSW Sydney application. Begin Music Ally LAUNCH application. Apply to Blackbird Giants. |
+| **August 2026** | Submit SXSW Sydney. Apply to MIDEM Accelerator. Apply for cloud credits (AWS, GCP). Research Seedstars regional events. Apply to Techstars Music. |
+| **September 2026** | Submit NZ Music Commission (DJ Zynrose). Begin Edmund Hillary Fellowship. Apply to FinTech Australia Awards (gTrade). Apply to Web Summit PITCH. |
+| **October 2026** | Product Hunt launch for SongPal beta. Apply to ITU AI for Good. Begin NZ Hi-Tech Awards. Apply to Slush 100. |
+| **November 2026** | Apply to Creative Australia Grants. Begin Anthropic Builder Programme application. Apply to Abbey Road Red. |
+| **December 2026** | Review all outcomes. Plan 2027 strategy. Position for Series A. |
 
 ---
 
 ## Tracking Notes
 
-- Update the **Dashboard** table at the top of this file as applications are submitted
-- Change status to: `Not started` → `Researching` → `Preparing` → `Submitted` → `Accepted` / `Rejected` / `Waitlisted`
-- Log outcomes and feedback in this section:
+Update the **Dashboard** table as applications progress:
+
+`Not started` → `Researching` → `Preparing` → `Submitted` → `Accepted` / `Rejected` / `Waitlisted`
 
 ### Application Log
 
@@ -375,7 +450,7 @@ Before entering any competition, confirm:
 
 ## Materials Checklist — Per Competition
 
-For each competition submission, prepare:
+For each submission, prepare:
 
 - [ ] Tailored executive summary (adapt from [COMPETITION_PORTFOLIO.md](COMPETITION_PORTFOLIO.md))
 - [ ] Pitch deck (adapt from [PITCH_DECK_OUTLINE.md](PITCH_DECK_OUTLINE.md))
@@ -383,11 +458,11 @@ For each competition submission, prepare:
 - [ ] Founder bio (copy from [PRESS_KIT.md](PRESS_KIT.md))
 - [ ] Financial projections (attach [FINANCIAL_MODEL.md](FINANCIAL_MODEL.md))
 - [ ] Contact email added
-- [ ] Eligibility criteria confirmed
+- [ ] Eligibility confirmed
 - [ ] Word/slide/video limits checked
 - [ ] Submission deadline calendared
 - [ ] Competition-specific angle identified (music / AI / fintech / startup)
 
 ---
 
-*Last updated: 2026-05-09 (Session 29) | Maintained by: Corey McIvor / COREINTENT*
+*Last updated: 2026-05-11 | Maintained by: Corey McIvor / COREINTENT*

--- a/COMPETITION_PORTFOLIO.md
+++ b/COMPETITION_PORTFOLIO.md
@@ -1,6 +1,6 @@
 # COMPETITION PORTFOLIO — Zynthio
 
-![Status](https://img.shields.io/badge/status-submission--ready-brightgreen) ![Updated](https://img.shields.io/badge/updated-2026--05--09-blue) ![Stage](https://img.shields.io/badge/stage-pre--seed-yellow) ![Jurisdiction](https://img.shields.io/badge/jurisdiction-New%20Zealand-black)
+![Status](https://img.shields.io/badge/status-submission--ready-brightgreen) ![Updated](https://img.shields.io/badge/updated-2026--05--11-blue) ![Stage](https://img.shields.io/badge/stage-pre--seed-yellow) ![Jurisdiction](https://img.shields.io/badge/jurisdiction-New%20Zealand-black)
 
 > Full competition portfolio for startup, AI, fintech, and music technology competitions worldwide.
 > Adapt per competition format. Every claim is verifiable. Every metric is honest.
@@ -9,27 +9,29 @@
 
 ## Executive Summary
 
-Zynthio is a sovereign AI ecosystem — seven brands delivering AI music production, autonomous algorithmic trading, education, and IP protection under one architecture. Built by a solo NZ/AU founder-engineer-producer incorporating in New Zealand, with live infrastructure and a ~$21B combined addressable market. One founder. One stack. All signal.
+Zynthio is a sovereign AI ecosystem — seven brands delivering AI music production, autonomous algorithmic trading, education, and IP protection under one architecture. Built by a solo NZ/AU founder-engineer-producer, incorporating in New Zealand, with live infrastructure and a ~$21B combined addressable market. One founder. One stack. All signal.
+
+*(50 words)*
 
 ---
 
 ## Problem Statement
 
-### The creator economy is broken — and AI trading is gatekept.
+### Creators are fragmented. Traders are gatekept. The full pipeline is broken.
 
-**1. AI tools are extractive, not empowering.**
-Independent creators face AI music tools that are expensive, opaque, and designed to capture — not protect — the value of creative output. Generative AI has collapsed the cost of production, but the platforms capturing that value give nothing back. Creators produce; platforms profit.
+**1. AI tools extract — they don't empower.**
+Generative AI has collapsed the cost of music production, but the platforms capturing that value give nothing back. Independent creators produce; platforms profit. Subscriptions are expensive, models are opaque, and IP terms are hostile.
 
-**2. AI-assisted trading is opaque, expensive, and gatekept.**
-Retail traders and independent builders are locked out of the algorithmic trading infrastructure that institutions take for granted. Signal services charge subscriptions for black-box calls with no accountability. Open, competition-based AI trading — where performance is the only metric and architecture is transparent — barely exists.
+**2. AI trading is a black box behind a paywall.**
+Retail traders are locked out of institutional-grade algorithmic infrastructure. What they get instead: subscription signal services selling unverifiable calls. No open architecture. No competition-based accountability. No way to see inside the machine.
 
-**3. Education is disconnected from real tools.**
-Music education platforms teach theory and legacy workflows. None of them teach creators how to use the actual AI tools reshaping their industry — because those platforms don't build tools. The knowledge gap is widening every quarter.
+**3. Education doesn't teach the real tools.**
+Music education platforms teach legacy workflows and theory — not the AI systems reshaping the industry. The knowledge gap widens every quarter because education platforms don't build tools.
 
-**4. IP infrastructure is inaccessible.**
-Trademark filings, licensing agreements, and copyright strategy remain locked behind expensive legal gatekeepers. Independent artists can create at scale, but they cannot protect at scale.
+**4. IP protection is inaccessible at scale.**
+Trademarks, licensing, and copyright strategy remain locked behind expensive legal gatekeepers. Creators can produce at scale but cannot protect at scale.
 
-**The result:** Creators and traders alike are fragmented across disconnected, extractive tools — paying more, owning less, and building on platforms that don't serve them. The post-AI economy needs new infrastructure, not new wrappers.
+**The structural failure:** These four problems compound each other. Creators and traders are spread across disconnected, extractive tools — paying more, owning less, building on infrastructure that doesn't serve them. The post-AI economy needs a new stack, not new wrappers around old ones.
 
 ---
 
@@ -41,21 +43,21 @@ Zynthio is a vertically integrated creative-technology ecosystem that solves the
 
 | Brand | Function | Status |
 |-------|----------|--------|
-| **ZYNTHIO** | Parent company — governance, partnerships, market-facing | Incorporating May 2026 |
-| **CoreIntent** | Dev studio, engineering, and autonomous trading (gTrade) — open, competition-based, multi-AI orchestration | **Live** |
+| **ZYNTHIO** | Parent company — governance, partnerships, market-facing | Incorporating May 2026 (NZ) |
+| **CoreIntent** | Dev studio + autonomous trading (gTrade) — open, competition-based, multi-AI orchestration | **Live** |
 | **SongPal** | AI-powered music production & collaboration platform | In development — TM filed (IPONZ #1318588) |
 | **CoreeyAI** | Multi-model AI orchestration layer (Claude, Grok, Perplexity, Suno) | **Live** |
 | **MOSOKO** | Music education — cohort programmes & self-paced courses | Curriculum in development |
 | **KERVALON** | Legal & IP management arm | Active |
 | **DJ Zynrose** | Artist persona — living proof of concept, community builder | Active — 2 tracks written |
 
-### What makes Zynthio different:
+### What makes this different:
 
 - **Sovereign architecture** — creators own 100% of their output. No extraction. No platform lock-in.
-- **Multi-AI orchestration** — CoreeyAI routes tasks across Claude, Grok, Perplexity, and Suno. Not a wrapper. Purpose-built routing for optimal model selection per task.
-- **Competition model over subscription** — CoreIntent's gTrade operates on performance-based, competition-style algorithmic trading. No black boxes, no monthly fees for signals. Open architecture, verifiable risk parameters. Performance is the product.
+- **Multi-AI orchestration** — CoreeyAI routes tasks across Claude, Grok, Perplexity, and Suno based on task requirements. Not a wrapper — purpose-built model selection.
+- **Competition model over subscription** — CoreIntent's gTrade uses performance-based, competition-style algorithmic trading. No black boxes. No monthly fees for signals. Open risk parameters. Performance is the product.
 - **Closed-loop ecosystem** — Build (CoreIntent) → Think (CoreeyAI) → Create (SongPal + DJ Zynrose) → Teach (MOSOKO) → Protect (KERVALON) → Scale (ZYNTHIO).
-- **Self-funding mechanism** — gTrade autonomous trading bot provides internal development funding without external dependency.
+- **Self-funding mechanism** — gTrade autonomous trading provides internal development capital without external dependency.
 
 ---
 
@@ -67,36 +69,47 @@ Zynthio is a vertically integrated creative-technology ecosystem that solves the
 | AI music generation | $1.5B | ~25% YoY |
 | Online music education | $2.1B | ~10% YoY |
 | Global retail trading (AI-assisted) | $12.0B+ | ~18% YoY |
-| **Combined Addressable Market** | **~$21.4B+** | |
+| **Combined Addressable Market** | **~$21.5B+** | |
 
 *Primary TAM (creator stack): ~$9.5B. Extended TAM (AI-assisted retail trading via gTrade): ~$12B+.*
 
-### Why now:
+### Why the timing is right:
 
-- Generative AI has collapsed the cost of music creation — the bottleneck is now **curation, pedagogy, and IP infrastructure**
-- AI-assisted investing is shifting from institutional to retail at pace — gTrade is positioned for this exact wave
-- No competitor offers a vertically integrated creator stack — the market is fragmented by design
+- Generative AI has collapsed production costs — the bottleneck is now **curation, pedagogy, and IP infrastructure**
+- AI-assisted investing is shifting from institutional to retail at pace — the subscription signal model is ripe for disruption by open, competition-based alternatives
 - Independent creators are the fastest-growing segment of the music industry
+- No competitor offers a vertically integrated sovereign creator stack — the market is fragmented by design
 - NZ/AU tech ecosystems are underserved by global AI tools built for US/EU markets
+
+### Comparable benchmarks:
+
+| Company | Stage | Revenue | Comparison |
+|---------|-------|---------|------------|
+| LANDR | Series B | $10M+ ARR | AI audio tools — comparable to SongPal |
+| Splice | Growth | $50M+ ARR | Creator tools SaaS |
+| Berklee Online | Established | $40M+ ARR | Music education — comparable to MOSOKO |
 
 ---
 
-## Founder
+## Team
 
-### Corey McIvor
+### Corey McIvor — Founder
 
 | Field | Detail |
 |-------|--------|
+| Role | Sole founder — architecture, code, brand, and music |
 | Citizenship | New Zealand / Australia (dual) |
 | Current location | Managua, Nicaragua |
-| Role | Sole founder — architecture, code, brand, and music |
-| Technical | Full-stack developer, AI engineer, Next.js / Python / Docker / CI-CD |
+| Technical | Full-stack developer, AI engineer — Next.js, Python, Docker, multi-model AI orchestration |
 | Creative | Independent music producer (DJ Zynrose) — electronic / experimental / ambient |
 | GitHub | [coreintentdev](https://github.com/coreintentdev) |
+| Doctrine | *No filler. All signal.* |
 
 **Why one founder matters:** Corey built the entire stack — the AI integrations, the production infrastructure, the brand architecture, the documentation, the music, and the legal filings. This is not a pitch deck looking for an engineer. The engineer is the founder.
 
 **Director qualification:** NZ/AU citizen — qualifies as eligible director under NZ Companies Act 1993 s 10(2A), regardless of physical location.
+
+**Why this person:** The engineer *is* the artist. The person building the tools is the person using them daily to create music. The person filing the trademark is the person writing the code the trademark protects. Alignment is total.
 
 ---
 
@@ -142,8 +155,8 @@ Zynthio is a vertically integrated creative-technology ecosystem that solves the
 - **Multi-model AI** — no single-vendor lock-in. CoreeyAI routes to the best model for each task.
 - **Sovereign infrastructure** — own VPS, own deployment pipeline, own data. No cloud dependency.
 - **Next.js for user-facing products** — modern React framework for SongPal and MOSOKO frontends.
-- **Modular brand architecture** — each brand pulls from CoreeyAI for the intelligence it needs.
-- **Open-source documentation** — ZYNTHIO_MASTER_DOCS is public. Transparency is a feature, not a risk.
+- **Modular brand architecture** — each brand draws intelligence from CoreeyAI as needed.
+- **Open-source documentation** — ZYNTHIO_MASTER_DOCS is public on GitHub. Transparency is a feature, not a risk.
 
 ---
 
@@ -151,22 +164,24 @@ Zynthio is a vertically integrated creative-technology ecosystem that solves the
 
 ### 1. Competition Model vs. Subscription (CoreIntent / gTrade)
 
-CoreIntent's gTrade operates on a performance-based competition model — autonomous, risk-managed algorithmic trading that funds development. This is not a subscription signal service selling black-box calls. No monthly fees for opaque signals. The bot competes in the market with open architecture and verifiable risk parameters:
+CoreIntent's gTrade operates on a performance-based competition model — autonomous, risk-managed algorithmic trading that funds development. This is not a subscription signal service selling black-box calls. The bot competes in the market with open architecture and verifiable risk parameters:
 
-- Max leverage: 5.0×
-- Max risk per trade: 1%
-- Daily loss ceiling: 0.8%
-- Assets: BTC-PERP, ETH-PERP, SOL-PERP, XAU-PERP, XAG-PERP
+| Parameter | Value |
+|-----------|-------|
+| Max leverage | 5.0× |
+| Max risk per trade | 1% |
+| Daily loss ceiling | 0.8% |
+| Assets | BTC-PERP, ETH-PERP, SOL-PERP, XAU-PERP, XAG-PERP |
 
-Performance is the product. Results speak for themselves. Open architecture means anyone can verify the risk parameters.
+Performance is the product. Open architecture means anyone can verify the risk parameters. No black boxes.
 
 ### 2. NZ Jurisdiction
 
 - Incorporating under NZ Companies Act 1993 — strong corporate governance framework
-- IPONZ trademark protection (SongPal #1318588)
+- IPONZ trademark protection (SongPal #1318588) — NZ IP infrastructure
 - NZ/AU tech and export education incentives align with SongPal and MOSOKO
 - Founder holds NZ/AU dual citizenship — deep jurisdictional alignment
-- NZ is not a flag-of-convenience — it's a strategic home for IP-heavy, creator-focused tech
+- Strategic home for IP-heavy, creator-focused tech — not a flag of convenience
 
 ### 3. Open Architecture
 
@@ -174,7 +189,7 @@ Performance is the product. Results speak for themselves. Open architecture mean
 - MIT-licensed codebase
 - Multi-model AI — no vendor lock-in
 - Creator sovereignty — users own 100% of their output
-- Verifiable risk parameters on gTrade — no black boxes
+- Verifiable risk parameters on gTrade
 
 ### 4. Vertical Integration
 
@@ -183,26 +198,26 @@ No competitor combines AI production + education + IP infrastructure + an artist
 | Competitor | What They Do | What Zynthio Does Differently |
 |------------|-------------|-------------------------------|
 | Suno / Udio | AI music generation | Integrates generation *within* a full creator stack |
-| Splice | Sample library & collaboration | AI-native and sovereignty-focused — creators own output |
+| Splice | Sample library & collaboration | AI-native, sovereignty-focused — creators own output |
 | Berklee Online | Music education | MOSOKO teaches *this specific stack* — tools are live products |
 | LANDR | AI mastering & distribution | Full pipeline: creation → education → legal → distribution |
-| Generic signal services | Black-box trading calls | gTrade: open architecture, competition model, verifiable risk |
+| Signal services | Black-box trading calls | gTrade: open architecture, competition model, verifiable risk |
 
 ---
 
 ## Traction Metrics
 
-*As of May 2026 — honest, early-stage, all verified:*
+*As of May 2026 — honest, early-stage, all verified.*
 
 ### Live & Operational
 
 | Asset | Status | Evidence |
 |-------|--------|----------|
-| Production infrastructure | **Live** | Sovereign VPS — Docker, Python 3.11, deployment pipeline running |
-| AI integrations | **Live** | Claude, Grok, Perplexity all active and wired into CoreeyAI |
-| gTrade autonomous trading | **Live** | Self-funding development — competition-based, open risk architecture |
+| Production infrastructure | **Live** | Sovereign VPS — Docker, Python 3.11, deployment pipeline |
+| AI integrations | **Live** | Claude, Grok, Perplexity active and wired into CoreeyAI |
+| gTrade autonomous trading | **Live** | Competition-based, open risk architecture, self-funding development |
 | Perplexity Orb | **Live** | Agentic session management deployed |
-| ZYNTHIO_MASTER_DOCS | **Live** | Comprehensive documentation for 7 brands, public on GitHub |
+| ZYNTHIO_MASTER_DOCS | **Live** | 7-brand documentation hub, public on GitHub |
 
 ### Filed & In Process
 
@@ -218,7 +233,7 @@ No competitor combines AI production + education + IP infrastructure + an artist
 |-------|--------|--------|
 | SongPal platform | MVP build underway | Beta Q2–Q3 2026 |
 | MOSOKO curriculum | First cohort planned | Q3 2026 |
-| Original music | 2 tracks written (SIGNAL 336, THE MIRROR ASKED A QUESTION) | 4-platform deployment pipeline in progress |
+| Original music | 2 tracks written (SIGNAL 336, THE MIRROR ASKED A QUESTION) | 4-platform deployment pending |
 
 ### Content & Community
 
@@ -226,13 +241,15 @@ No competitor combines AI production + education + IP infrastructure + an artist
 - **Seven-brand architecture** fully documented with brand guidelines, roadmaps, and asset registries
 - **Open-source presence:** [github.com/coreintentdev](https://github.com/coreintentdev)
 
-### What we don't have yet (and we're honest about it):
+### What we don't have yet — and we're honest about it:
 
 - No paying customers (pre-revenue — SaaS launch target Q4 2026)
 - No external funding raised (bootstrapped + gTrade self-funding)
 - Solo founder (no team hires yet — this is intentional at this stage)
 - SongPal beta not yet launched
 - No streaming platform presence for DJ Zynrose (deployment pending)
+
+The architecture is real. The revenue is next.
 
 ---
 
@@ -305,4 +322,4 @@ Email: *(add contact email before submitting)*
 
 ---
 
-*Last updated: 2026-05-09 (Session 29) | Maintained by: Corey McIvor / COREINTENT*
+*Last updated: 2026-05-11 | Maintained by: Corey McIvor / COREINTENT*

--- a/DEMO_SCRIPT.md
+++ b/DEMO_SCRIPT.md
@@ -1,15 +1,13 @@
 # DEMO SCRIPT — Zynthio
 
-![Status](https://img.shields.io/badge/status-submission--ready-brightgreen) ![Updated](https://img.shields.io/badge/updated-2026--05--09-blue) ![Duration](https://img.shields.io/badge/duration-3%20minutes-purple)
+![Status](https://img.shields.io/badge/status-submission--ready-brightgreen) ![Updated](https://img.shields.io/badge/updated-2026--05--11-blue) ![Duration](https://img.shields.io/badge/duration-3%20minutes-purple)
 
 > 3-minute live demo walkthrough for competitions, investor meetings, and showcases.
-> Designed to show the real stack — not a prototype, not a mockup.
+> This is the real stack — not a prototype, not a mockup.
 
 ---
 
 ## Pre-Demo Checklist
-
-Before going live, confirm:
 
 - [ ] VPS is accessible and services are running
 - [ ] CoreeyAI integrations responding (Claude, Grok, Perplexity)
@@ -17,7 +15,7 @@ Before going live, confirm:
 - [ ] SongPal demo environment ready (or fallback: architecture walkthrough)
 - [ ] gTrade dashboard accessible (or fallback: risk config display)
 - [ ] Browser tabs pre-loaded: zynthio.ai, GitHub repo, VPS terminal, SongPal (if available)
-- [ ] Audio output tested (for music playback segment)
+- [ ] Audio output tested (for music playback)
 - [ ] Backup: offline screenshots / screen recording if WiFi fails
 
 ---
@@ -28,13 +26,11 @@ Before going live, confirm:
 
 **Say:**
 
-> "Let me show you what Zynthio actually looks like. This isn't a mockup — this is live infrastructure, running right now on our own sovereign server."
+> "Let me show you what Zynthio actually looks like. This isn't a mockup. This is live infrastructure, running right now on our own sovereign server."
 
-**Action:** Open terminal or browser showing VPS status / Docker containers running.
+**Action:** Open terminal or browser showing VPS status — Docker containers running, health checks passing.
 
-**Show:** Docker container list — services running, health checks passing. The audience sees real infrastructure, not slides.
-
-**Impact:** Establishes credibility immediately. Most early-stage startups show Figma prototypes. You're showing running containers.
+**Impact:** Most early-stage startups show Figma. You're showing running containers.
 
 ---
 
@@ -42,18 +38,18 @@ Before going live, confirm:
 
 **Say:**
 
-> "This is CoreeyAI — our multi-model AI orchestration layer. It doesn't just call one API. It routes tasks to the right model for the job — Claude for reasoning, Grok for real-time data, Perplexity for research, Suno for generation."
+> "This is CoreeyAI — our multi-model AI orchestration layer. It doesn't call one API. It routes tasks to the right model for the job — Claude for reasoning, Grok for real-time data, Perplexity for research, Suno for generation."
 
-**Action:** Trigger a live CoreeyAI query — send a prompt that demonstrates model routing.
+**Action:** Trigger a live CoreeyAI query — a prompt demonstrating model routing.
 
 **Show:**
 - A composition prompt sent to CoreeyAI
-- CoreeyAI routing to Claude for arrangement logic, Perplexity for genre research
-- Response returned with structured output showing which model handled which subtask
+- Routing to Claude for arrangement logic, Perplexity for genre research
+- Structured response showing which model handled which subtask
 
 **Say:**
 
-> "That's three AI models, orchestrated in one call. This is what powers SongPal — and what makes our gTrade trading bot intelligent."
+> "Three AI models, orchestrated in one call. This is what powers SongPal — and what makes our trading bot intelligent."
 
 ---
 
@@ -65,30 +61,29 @@ Before going live, confirm:
 
 > "This is SongPal — our AI music production platform. Trademark filed in New Zealand. Built on Next.js with CoreeyAI underneath."
 
-**Action:** Open SongPal interface. Demonstrate:
+**Action:**
 1. Start a new track session
-2. Enter a creative prompt (e.g., "ambient electronic, 120 BPM, atmospheric pads, minimal percussion")
-3. Show CoreeyAI processing the prompt
-4. Play back the generated audio snippet
+2. Enter a creative prompt ("ambient electronic, 120 BPM, atmospheric pads, minimal percussion")
+3. Show CoreeyAI processing
+4. Play back the generated audio
 
 **Say:**
 
-> "That's original audio, created in seconds, using our own AI layer. The creator owns 100% of it. No licensing traps. No extraction. This is creative sovereignty."
+> "Original audio, created in seconds, on our own AI layer. The creator owns 100%. No licensing traps. No extraction. Creative sovereignty."
 
-**If SongPal MVP is not yet ready (fallback):**
-
-**Say:**
-
-> "SongPal is in active development — trademark filed, Next.js frontend building, beta targeting this quarter. Let me show you the architecture that powers it, and play you something it will produce."
-
-**Action:** Show the ECOSYSTEM_MAP.md architecture diagram on GitHub. Walk through the data flow:
-- CoreIntent builds → CoreeyAI thinks → SongPal creates → MOSOKO teaches → KERVALON protects
-
-**Play:** A 15-second clip of *SIGNAL 336* or *THE MIRROR ASKED A QUESTION*.
+**If SongPal MVP is not ready (fallback):**
 
 **Say:**
 
-> "This track was made using the Zynthio stack. DJ Zynrose — my artist project — is the living proof of concept. Every track is made on the same tools we're building for everyone."
+> "SongPal is in active development — trademark filed, Next.js frontend building, beta this quarter. Let me show you the architecture, and play you something the stack produces."
+
+**Action:** Show ECOSYSTEM_MAP.md architecture diagram on GitHub. Walk the flow: CoreIntent builds → CoreeyAI thinks → SongPal creates → MOSOKO teaches → KERVALON protects.
+
+**Play:** 15-second clip of *SIGNAL 336* or *THE MIRROR ASKED A QUESTION*.
+
+**Say:**
+
+> "This track was made using the Zynthio stack. DJ Zynrose — my artist project — is the living proof of concept."
 
 ---
 
@@ -96,40 +91,40 @@ Before going live, confirm:
 
 **Say:**
 
-> "Most early-stage startups burn cash while they build. We built a different mechanism. This is gTrade — CoreIntent's autonomous trading bot."
+> "Most early-stage startups burn cash while they build. We built a different mechanism."
 
-**Action:** Show gTrade dashboard or risk configuration (config/risk.yaml).
+**Action:** Show gTrade dashboard or risk configuration.
 
 **Show:**
-- Asset coverage: BTC-PERP, ETH-PERP, SOL-PERP, XAU-PERP, XAG-PERP
+- Assets: BTC-PERP, ETH-PERP, SOL-PERP, XAU-PERP, XAG-PERP
 - Risk parameters: max leverage 5.0×, 1% max risk per trade, 0.8% daily loss ceiling
 - Status: live, autonomous, risk-managed
 
 **Say:**
 
-> "This is the CoreIntent difference. Not a subscription signal service — a competition-based model. Open architecture. Verifiable risk parameters. Max 5x leverage, 1% risk per trade, 0.8% daily loss ceiling. Every parameter is transparent."
+> "This is gTrade. Not a subscription signal service — a competition-based model. Open architecture. Every risk parameter is transparent and verifiable. Max 5x leverage. 1% risk per trade. 0.8% daily loss ceiling."
 
 **Pause.**
 
-> "This is how we stay sovereign while we build. gTrade funds development. No VC dependency. No runway anxiety. The bot competes in the market and the results fund better tools."
+> "This is how we stay sovereign while we build. gTrade funds development. No VC dependency. The bot competes in the market and the results fund better tools."
 
 ---
 
-### [2:10–2:40] The Documentation & Brand Architecture
+### [2:10–2:40] Documentation & Brand Architecture
 
 **Say:**
 
-> "One thing that sets Zynthio apart from every other early-stage startup I've seen — everything is documented, public, and structured."
+> "One thing that sets Zynthio apart — everything is documented, public, and structured."
 
-**Action:** Open GitHub repo (ZYNTHIO_MASTER_DOCS). Scroll through:
+**Action:** Open ZYNTHIO_MASTER_DOCS on GitHub. Scroll through:
 - INDEX.md — master table of contents
-- 7 brand directories, each with README, ROADMAP, ASSETS
-- 19 multilingual avatar scripts (6 languages)
+- 7 brand directories (README, ROADMAP, ASSETS each)
+- 19 multilingual avatar scripts
 - FINANCIAL_MODEL.md, NZ_COMPLIANCE.md
 
 **Say:**
 
-> "Seven brands. Full documentation. Brand guidelines, roadmaps, financial projections, NZ compliance tracking, multilingual content in six languages — all in one public repo. This is how you build a real company, not just a demo."
+> "Seven brands. Full documentation. Financial projections. NZ compliance tracking. Six languages. All in one public repo. This is how you build a real company."
 
 ---
 
@@ -139,15 +134,15 @@ Before going live, confirm:
 
 > "Let me leave you with this."
 
-**Action:** Return to the terminal / VPS view. Services running.
+**Action:** Return to terminal / VPS view. Services running.
 
 **Say:**
 
-> "What you just saw is not a pitch deck. It's a running system. Live infrastructure. Multi-model AI. A trademark on file. A company incorporating in New Zealand this month. An autonomous trading bot funding development. Original music written and ready to deploy. And a founder who built every layer — the code, the brand, the music, and the legal filings."
+> "What you just saw is not a pitch deck. It's a running system. Live infrastructure. Multi-model AI. A trademark on file. A company incorporating in New Zealand. An autonomous trading bot funding development. Original music written and ready to deploy. And a founder who built every layer — the code, the brand, the music, and the legal filings."
 
-**Pause. Make eye contact.**
+**Pause. Eye contact.**
 
-> "Zynthio is not a feature. It's sovereign creative infrastructure for the post-AI world. One stack. Seven brands. No filler. All signal."
+> "Zynthio is sovereign creative infrastructure for the post-AI world. One stack. Seven brands. No filler. All signal."
 
 ---
 
@@ -164,44 +159,43 @@ Before going live, confirm:
 
 ---
 
-## Adaptation Notes
+## Adaptation by Competition Type
 
-### For AI competitions (emphasise CoreeyAI):
-- Extend the CoreeyAI segment to 60 seconds
+### AI competitions — emphasise CoreeyAI
+- Extend CoreeyAI segment to 60 seconds
 - Show prompt engineering templates and agentic workflow (Perplexity Orb)
-- Demonstrate model selection logic — why Claude for reasoning, Grok for real-time, Perplexity for research
+- Demonstrate model selection logic
 - Trim documentation segment to 15 seconds
 
-### For music competitions (emphasise SongPal + DJ Zynrose):
-- Lead with music playback — open with 10 seconds of *SIGNAL 336*
+### Music competitions — emphasise SongPal + DJ Zynrose
+- Lead with 10 seconds of *SIGNAL 336* audio
 - Extend SongPal segment to 60 seconds
 - Show MOSOKO curriculum outline
-- Trim gTrade to 15 seconds — mention it as "how we self-fund" without deep dive
+- Trim gTrade to 15 seconds ("how we self-fund")
 
-### For fintech / trading competitions (emphasise CoreIntent / gTrade):
+### Fintech / trading competitions — emphasise CoreIntent / gTrade
 - Lead with gTrade — open risk config immediately
-- Extend gTrade segment to 90 seconds — show live positions, risk parameters, asset coverage
-- Emphasise the competition model vs. subscription model difference
-- Show the open architecture principle — anyone can verify the risk parameters
-- Show FINANCIAL_MODEL.md projections on screen
+- Extend gTrade segment to 90 seconds — live positions, risk parameters, asset coverage
+- Emphasise competition model vs. subscription model
+- Show FINANCIAL_MODEL.md projections
 
-### For startup competitions (emphasise business model):
+### Startup competitions — emphasise business model
 - Lead with market size ($21B+ combined TAM)
-- Balance between SongPal product and gTrade self-funding
-- Show FINANCIAL_MODEL.md projections on screen
-- Close with funding ask — NZD $150–250K seed
+- Balance SongPal product and gTrade self-funding
+- Show FINANCIAL_MODEL.md projections
+- Close with funding ask: NZD $150–250K seed
 
 ### If WiFi fails:
-- Pre-record a 3-minute screen capture as backup
-- Have offline screenshots of all key screens
-- Music clips stored locally on device
+- Pre-recorded 3-minute screen capture as backup
+- Offline screenshots of all key screens
+- Music clips stored locally
 - Risk config YAML viewable offline
 
 ---
 
-## Key Quotes to Land
+## Key Lines to Land
 
-Use one or two of these during the demo, depending on audience:
+Pick one or two per demo, matched to the audience:
 
 - *"The engineer is the artist. The person building the tools is the person using them."*
 - *"We don't burn cash while we build. gTrade funds our development autonomously."*
@@ -211,4 +205,4 @@ Use one or two of these during the demo, depending on audience:
 
 ---
 
-*Last updated: 2026-05-09 (Session 29) | Maintained by: Corey McIvor / COREINTENT*
+*Last updated: 2026-05-11 | Maintained by: Corey McIvor / COREINTENT*

--- a/PITCH_DECK_OUTLINE.md
+++ b/PITCH_DECK_OUTLINE.md
@@ -1,6 +1,6 @@
 # PITCH DECK OUTLINE — Zynthio
 
-![Status](https://img.shields.io/badge/status-submission--ready-brightgreen) ![Updated](https://img.shields.io/badge/updated-2026--05--09-blue) ![Slides](https://img.shields.io/badge/slides-10-purple)
+![Status](https://img.shields.io/badge/status-submission--ready-brightgreen) ![Updated](https://img.shields.io/badge/updated-2026--05--11-blue) ![Slides](https://img.shields.io/badge/slides-10-purple)
 
 > 10-slide pitch deck structure with full content for each slide.
 > Designed for startup, AI, fintech, and music technology competitions.
@@ -14,9 +14,9 @@
 
 **Tagline:** *The sovereign creative stack.*
 
-**Subtitle:** AI-powered music production, autonomous trading, and creator infrastructure — one ecosystem, seven brands, built by one founder.
+**Subtitle:** AI music production · autonomous trading · creator infrastructure — one ecosystem, seven brands, one founder.
 
-**Visual:** Zynthio wordmark on #0A0A0A background. Signal Gold (#C9A84C) accent line. Domain: zynthio.ai
+**Visual:** Zynthio wordmark on #0A0A0A background. Signal Gold (#C9A84C) accent line.
 
 **Footer:** Corey McIvor | Founder | NZ/AU | zynthio.ai
 
@@ -24,29 +24,27 @@
 
 ## Slide 2 — The Problem
 
-### Independent creators and traders are fragmented across broken infrastructure.
+### The creative and trading infrastructure is broken.
 
-**Four pain points:**
+**Four converging failures:**
 
-1. **AI tools are extractive.** Generative music platforms capture value from creators — expensive subscriptions, opaque models, IP-hostile terms. Creators produce; platforms profit.
+1. **AI tools are extractive.** Generative music platforms capture value from creators — expensive subscriptions, opaque models, IP-hostile terms.
 
-2. **AI trading is gatekept.** Algorithmic trading infrastructure is institutional-grade and institutional-priced. Retail traders get black-box signal subscriptions with no transparency, no accountability, and no open architecture. Performance claims are unverifiable.
+2. **AI trading is gatekept.** Retail traders get black-box signal subscriptions with no transparency, no accountability, and no open architecture.
 
-3. **Education is disconnected.** Music schools teach legacy workflows. None of them teach the AI tools reshaping the industry — because they don't build tools. The gap between curriculum and reality grows every quarter.
+3. **Education is disconnected from real tools.** Music schools teach legacy workflows. None teach the AI tools reshaping the industry — because they don't build tools.
 
-4. **IP protection is inaccessible.** Trademarks, licensing, and copyright strategy are locked behind expensive legal gatekeepers. Creators can produce at scale but cannot protect at scale.
+4. **IP protection is inaccessible.** Trademarks and copyright strategy are locked behind expensive legal gatekeepers. Creators can produce at scale but cannot protect at scale.
 
-**Key stat:** The combined addressable market across music production, AI music, online education, and AI-assisted retail trading exceeds **$21 billion** — and no one offers the full stack.
+**Key stat:** The combined addressable market exceeds **$21 billion** — and no one offers the full stack.
 
-**Visual:** Four icons (lock, broken chain, shield with X, blindfold). Simple, dark background.
+**Visual:** Four icons on dark background — broken chain, blindfold, disconnect symbol, locked shield.
 
 ---
 
 ## Slide 3 — The Solution
 
 ### Zynthio: One stack. Seven brands. Full pipeline.
-
-**Architecture diagram:**
 
 ```
 ZYNTHIO (Parent — NZ incorporated)
@@ -55,14 +53,14 @@ ZYNTHIO (Parent — NZ incorporated)
 ├── CoreeyAI — Multi-model AI orchestration (Claude, Grok, Perplexity, Suno)
 ├── MOSOKO — Education for sovereign creators
 ├── DJ Zynrose — Artist persona + living proof of concept
-├── KERVALON — Legal & IP protection
+└── KERVALON — Legal & IP protection
 ```
 
-**Key message:** Zynthio is not a product. It is infrastructure for creative sovereignty. Build → Think → Create → Teach → Protect → Scale. Every brand reinforces every other.
+**Key message:** Zynthio is not a product. It is infrastructure for creative sovereignty.
 
-**CoreIntent difference:** gTrade operates on a competition model, not a subscription model. Open architecture, verifiable risk parameters, performance-based. This funds the entire ecosystem autonomously.
+**CoreIntent difference:** gTrade operates on a competition model, not a subscription model. Open architecture, verifiable risk parameters, performance-based — and it funds the entire ecosystem autonomously.
 
-**Visual:** Clean architecture diagram with Signal Gold connections between brands on dark background.
+**Visual:** Architecture diagram with Signal Gold connections between brands.
 
 ---
 
@@ -72,18 +70,18 @@ ZYNTHIO (Parent — NZ incorporated)
 
 | Step | Brand | Action |
 |------|-------|--------|
-| 1. **Build** | CoreIntent | Engineers world-class tools + funds via gTrade |
+| 1. **Build** | CoreIntent | Engineers tools + funds via gTrade autonomous trading |
 | 2. **Think** | CoreeyAI | Multi-model AI orchestration (Claude, Grok, Perplexity, Suno) |
-| 3. **Create** | SongPal + DJ Zynrose | Produces music with AI assistance — creator owns 100% |
-| 4. **Teach** | MOSOKO | Spreads the capability to independent creators |
+| 3. **Create** | SongPal + DJ Zynrose | Produces music with AI — creator owns 100% |
+| 4. **Teach** | MOSOKO | Spreads the capability to independent creators worldwide |
 | 5. **Protect** | KERVALON | Locks in IP value — trademarks, copyright, licensing |
 | 6. **Scale** | ZYNTHIO | Takes the whole stack to market |
 
 **Key differentiator:** DJ Zynrose is the living proof of concept. Every track is made on SongPal, taught through MOSOKO, and protected by KERVALON. The artist *is* the product demo.
 
-**Self-funding loop:** gTrade → development capital → better tools → more users → more data → smarter AI. No external funding required to operate.
+**Self-funding loop:** gTrade → development capital → better tools → more users → smarter AI. No external funding required to operate.
 
-**Visual:** Circular flow diagram. Six steps, Signal Gold arrows, brand logos at each node.
+**Visual:** Circular flow diagram. Six steps, Signal Gold arrows.
 
 ---
 
@@ -98,43 +96,39 @@ ZYNTHIO (Parent — NZ incorporated)
 | Online music education | $2.1B | +10% YoY |
 | AI-assisted retail trading | $12.0B+ | +18% YoY |
 
-*Primary TAM (creator stack): ~$9.5B. Extended TAM (AI-assisted trading via gTrade): ~$12B+.*
-
 **Why now:**
-- Generative AI has collapsed production costs — the bottleneck is now curation, pedagogy, and IP
-- AI-assisted investing is shifting from institutional to retail — the subscription signal model is ripe for disruption
+- Generative AI collapsed production costs — the bottleneck shifted to curation, pedagogy, and IP
+- AI trading is shifting from institutional to retail — subscription signals are ripe for disruption
 - Independent creators are the fastest-growing music segment
 - No competitor offers a vertically integrated sovereign stack
 
-**Comparable exits / benchmarks:**
-- LANDR (Series B): $10M+ ARR — AI audio tools
-- Splice (Growth): $50M+ ARR — creator tools SaaS
-- Berklee Online: $40M+ ARR — music education
+**Comparable benchmarks:**
+- LANDR (Series B): $10M+ ARR
+- Splice (Growth): $50M+ ARR
+- Berklee Online: $40M+ ARR
 
-**Visual:** Market size bars with Zynthio's position highlighted. Growth arrows on AI segment.
+**Visual:** Market size bars. Growth arrows on AI segments.
 
 ---
 
 ## Slide 6 — Business Model
 
-### Five revenue streams across four brands.
+### Five revenue streams. Self-funding core.
 
-| Stream | Brand | Model | Target Launch |
-|--------|-------|-------|---------------|
+| Stream | Brand | Model | Launch |
+|--------|-------|-------|--------|
 | **SongPal SaaS** | SongPal | Monthly subscriptions (Free / Creator / Studio) | Q4 2026 |
 | **MOSOKO Courses** | MOSOKO | Cohort programmes + self-paced modules | Q3 2026 |
 | **CoreeyAI API** | CoreeyAI | B2B per-call or monthly licensing | Q4 2026 |
 | **KERVALON Services** | KERVALON | IP consulting + TM filing for indie artists | Q4 2026+ |
-| **gTrade Performance** | CoreIntent | Competition-based autonomous trading (internal + future external) | **Live now** |
+| **gTrade Performance** | CoreIntent | Competition-based autonomous trading (live) | **Now** |
 
-**Internal funding:** gTrade autonomous trading bot (live) self-funds development. Not dependent on external capital to operate.
+**Internal funding:** gTrade self-funds development. Not dependent on external capital to operate.
 
-**Unit economics (SongPal):**
-- ARPU: NZD $20–30/mo
-- Target LTV:CAC: 6–8×
-- 12-month LTV: NZD $240–360
+**SongPal unit economics:**
+- ARPU: NZD $20–30/mo | LTV:CAC: 6–8× | 12-month LTV: NZD $240–360
 
-**Visual:** Revenue stream diagram with brand-coloured bars. gTrade shown as separate self-funding loop.
+**Visual:** Revenue stream diagram. gTrade shown as self-funding loop.
 
 ---
 
@@ -143,26 +137,26 @@ ZYNTHIO (Parent — NZ incorporated)
 ### Early stage. Real infrastructure. Honest metrics.
 
 **Live & operational:**
-- Production infrastructure: sovereign VPS, Docker, Next.js + Python 3.11, deployment pipeline
-- AI integrations: Claude, Grok, Perplexity — all active in CoreeyAI
-- gTrade: Autonomous trading bot — live, competition-based, self-funding development
+- Sovereign VPS with Docker, Next.js, Python 3.11 deployment pipeline
+- CoreeyAI: Claude, Grok, Perplexity integrations — all active
+- gTrade: Autonomous trading bot — live, competition-based, self-funding
 - Perplexity Orb: Agentic session management — deployed
-- Documentation: 7-brand architecture fully documented, public on GitHub
+- 7-brand documentation hub — public on GitHub
 
 **Filed & in process:**
-- SongPal trademark: IPONZ #1318588 — filed, awaiting examination
+- SongPal™ trademark: IPONZ #1318588 — filed, awaiting examination
 - ZYNTHIO LIMITED: NZ Companies Office #15436626 — incorporating May 2026
 - Domain: zynthio.ai — active
 
 **In development:**
-- SongPal MVP (Next.js) — beta target Q2–Q3 2026
+- SongPal MVP (Next.js) — beta Q2–Q3 2026
 - MOSOKO curriculum — first cohort Q3 2026
-- 2 original tracks written (SIGNAL 336, THE MIRROR ASKED A QUESTION)
+- 2 original tracks: *SIGNAL 336*, *THE MIRROR ASKED A QUESTION*
 - 19 multilingual avatar scripts across 6 languages
 
 **What we don't have yet:** Paying customers, external funding, a team beyond the founder, streaming presence. We're pre-revenue and we're honest about it. The architecture is real. The revenue is next.
 
-**Visual:** Timeline with checkmarks (done) and open circles (in progress). Clean, no false metrics.
+**Visual:** Timeline with checkmarks (done) and open circles (next). No false metrics.
 
 ---
 
@@ -170,20 +164,20 @@ ZYNTHIO (Parent — NZ incorporated)
 
 ### No one else offers the full stack.
 
-| | Suno/Udio | Splice | Berklee Online | LANDR | Signal subs | **Zynthio** |
+| | Suno/Udio | Splice | Berklee | LANDR | Signal subs | **Zynthio** |
 |---|:-:|:-:|:-:|:-:|:-:|:-:|
-| AI music production | Yes | No | No | Partial | No | **Yes** |
-| Education platform | No | No | Yes | No | No | **Yes** |
-| IP / legal protection | No | No | No | No | No | **Yes** |
-| Artist proof-of-concept | No | No | No | No | No | **Yes** |
-| Open trading architecture | No | No | No | No | No | **Yes** |
-| Competition-based funding | No | No | No | No | No | **Yes** |
-| Creator owns 100% | Varies | Yes | N/A | Yes | N/A | **Yes** |
-| Multi-model AI | No | No | No | No | No | **Yes** |
+| AI music production | ✓ | — | — | ~ | — | **✓** |
+| Education platform | — | — | ✓ | — | — | **✓** |
+| IP / legal protection | — | — | — | — | — | **✓** |
+| Artist proof-of-concept | — | — | — | — | — | **✓** |
+| Open trading architecture | — | — | — | — | — | **✓** |
+| Self-funding mechanism | — | — | — | — | — | **✓** |
+| Creator owns 100% | ~ | ✓ | n/a | ✓ | n/a | **✓** |
+| Multi-model AI | — | — | — | — | — | **✓** |
 
-**The moat:** Vertical integration + self-funding mechanism. Every new user feeds the entire ecosystem. gTrade funds development without dilution. The stack gets stronger with time, not weaker.
+**The moat:** Vertical integration + self-funding. Every new user feeds the ecosystem. gTrade funds development without dilution. The stack compounds.
 
-**Visual:** Feature matrix with checkmarks. Competitors greyed out. Zynthio column in Signal Gold.
+**Visual:** Feature matrix. Competitors greyed out. Zynthio column in Signal Gold.
 
 ---
 
@@ -195,29 +189,29 @@ ZYNTHIO (Parent — NZ incorporated)
 - **Location:** Managua, Nicaragua (operating globally)
 - **Technical:** Full-stack developer, AI engineer — Next.js, Python, Docker, multi-model AI orchestration
 - **Creative:** Independent music producer (DJ Zynrose) — electronic / experimental / ambient
-- **Built:** The entire Zynthio stack — architecture, code, AI, brand, legal filings, music, and documentation. Solo.
+- **Built:** The entire Zynthio stack — architecture, code, AI, brand, legal filings, music, documentation. Solo.
 
 **Why this founder:**
-- The engineer *is* the artist. The person building the tools is also the person using them to create music. This is not theoretical — it's tested daily.
-- NZ/AU citizen — qualified NZ company director, aligned with NZ tech ecosystem
-- Resourceful: bootstrapped with ~NZD $300–500/month burn, self-funded via gTrade
-- Built a seven-brand architecture with live infrastructure before raising a single dollar
+- The engineer *is* the artist. Building the tools and using them daily to create music.
+- NZ/AU citizen — qualified NZ company director under Companies Act 1993
+- Bootstrapped with ~NZD $300–500/month burn, self-funded via gTrade
+- Built a seven-brand architecture with live infrastructure before raising a dollar
 
-**Visual:** Founder photo (if available). GitHub contribution graph. Clean, minimal layout.
+**Visual:** Founder photo (if available). GitHub contribution graph. Minimal layout.
 
 ---
 
 ## Slide 10 — The Ask
 
-### What we need. What we'll do with it.
+### What we need. What we'll build with it.
 
 **Seed raise:** NZD $150,000–250,000
 
 | Allocation | % | Amount (NZD $200K) |
 |-----------|---|-------------------|
 | SongPal development (Next.js + AI) | 35% | $70,000 |
-| MOSOKO curriculum | 20% | $40,000 |
-| Marketing & community | 20% | $40,000 |
+| MOSOKO curriculum production | 20% | $40,000 |
+| Marketing & community building | 20% | $40,000 |
 | Legal, IP, compliance | 10% | $20,000 |
 | Infrastructure & tools | 5% | $10,000 |
 | Operating reserve | 10% | $20,000 |
@@ -228,43 +222,43 @@ ZYNTHIO (Parent — NZ incorporated)
 - CoreeyAI: First B2B API client
 - gTrade: Expanded asset coverage, published performance metrics
 - DJ Zynrose: Tracks deployed, 1,000+ streams
-- ZYNTHIO LIMITED: Incorporated, operating, first annual return filed
+- ZYNTHIO LIMITED: Fully operational, first annual return filed
 
 **3-year revenue trajectory:** ~NZD $1.3M cumulative
 
-**Closing line:** *"We're not pitching a feature. We're pitching a new creative infrastructure for the post-AI world. One stack. Seven brands. No filler. All signal."*
+**Closing line:** *"We're not pitching a feature. We're pitching new creative infrastructure for the post-AI world. One stack. Seven brands. No filler. All signal."*
 
-**Visual:** Use-of-funds pie chart. 12-month milestone timeline. zynthio.ai + contact info.
+**Visual:** Use-of-funds pie chart. Milestone timeline. zynthio.ai + contact.
 
 ---
 
-## Appendix — Slide Design Guidelines
+## Appendix — Design Specifications
 
 | Element | Specification |
 |---------|----------------|
 | Background | Zynthio Black (#0A0A0A) |
 | Primary text | Zynthio White (#F5F5F5) |
 | Accent | Signal Gold (#C9A84C) |
-| Secondary accent | Electric Cyan (#00D4FF) for AI/tech callouts |
-| Headings | Space Grotesk, 700 weight |
-| Body | Inter, 400 weight |
-| Data / code | JetBrains Mono, 400 weight |
+| Secondary accent | Electric Cyan (#00D4FF) |
+| Headings | Space Grotesk, 700 |
+| Body | Inter, 400 |
+| Data / code | JetBrains Mono, 400 |
 | Slide ratio | 16:9 |
-| Max words per slide | 80–100 (audiences read less than you think) |
+| Max words per slide | 80–100 |
 
 ---
 
 ## Delivery Notes
 
-- **Time:** 5–7 minutes for full deck. 3 minutes if trimmed to slides 1–4, 7, 10.
+- **Time:** 5–7 minutes full deck. 3 minutes if trimmed to slides 1–4, 7, 10.
 - **Tone:** Bold but honest. Confident, not hype. Acknowledge early stage — then show what's real.
-- **Adaptation:**
-  - For music competitions: lead with slides 3–4 (SongPal + DJ Zynrose).
-  - For AI competitions: lead with slide 4 (CoreeyAI multi-model architecture).
-  - For fintech competitions: lead with slides 3, 6 (CoreIntent / gTrade competition model).
-  - For startup competitions: lead with slides 5–6 (market + business model).
-- **Demo integration:** If live demo is allowed, insert between slides 7 and 8. See [DEMO_SCRIPT.md](DEMO_SCRIPT.md).
+- **Adaptation by competition type:**
+  - **Music competitions:** Lead with slides 3–4 (SongPal + DJ Zynrose).
+  - **AI competitions:** Lead with slide 4 (CoreeyAI multi-model architecture).
+  - **Fintech competitions:** Lead with slides 3, 6 (CoreIntent / gTrade competition model).
+  - **Startup competitions:** Lead with slides 5–6 (market + business model).
+- **Demo integration:** If live demo is permitted, insert between slides 7 and 8. See [DEMO_SCRIPT.md](DEMO_SCRIPT.md).
 
 ---
 
-*Last updated: 2026-05-09 (Session 29) | Maintained by: Corey McIvor / COREINTENT*
+*Last updated: 2026-05-11 | Maintained by: Corey McIvor / COREINTENT*

--- a/PRESS_KIT.md
+++ b/PRESS_KIT.md
@@ -1,6 +1,6 @@
 # PRESS KIT — Zynthio
 
-![Status](https://img.shields.io/badge/status-submission--ready-brightgreen) ![Updated](https://img.shields.io/badge/updated-2026--05--09-blue)
+![Status](https://img.shields.io/badge/status-submission--ready-brightgreen) ![Updated](https://img.shields.io/badge/updated-2026--05--11-blue)
 
 > Press kit for media, competition judges, event organisers, and partners.
 > Copy any section directly into submissions, bios, or press materials.
@@ -15,23 +15,23 @@ Zynthio is a sovereign AI-powered creative ecosystem built by Corey McIvor — a
 
 ### The Medium Version (150 words)
 
-Independent creators are fragmented across broken tooling — expensive AI platforms that extract value, education systems disconnected from real tools, and legal infrastructure they can't access. AI trading is no better: black-box signal subscriptions with no transparency. Zynthio solves both problems with a vertically integrated creative-technology ecosystem.
+Independent creators are fragmented across broken tooling — expensive AI platforms that extract value, education systems disconnected from real tools, and legal infrastructure they can't access. AI trading is no better: black-box signal subscriptions with no transparency or accountability.
 
-Seven brands operate as one system: SongPal (AI music production, trademark filed), CoreeyAI (multi-model AI orchestration across Claude, Grok, Perplexity, Suno), MOSOKO (creator education), DJ Zynrose (artist proof of concept), CoreIntent (dev studio and autonomous competition-based trading via gTrade), KERVALON (legal and IP protection), and ZYNTHIO (parent company, incorporating in New Zealand).
+Zynthio solves both problems with a vertically integrated creative-technology ecosystem. Seven brands operate as one system: SongPal (AI music production, trademark filed), CoreeyAI (multi-model AI orchestration across Claude, Grok, Perplexity, Suno), MOSOKO (creator education), DJ Zynrose (artist proof of concept), CoreIntent (dev studio and autonomous competition-based trading via gTrade), KERVALON (legal and IP protection), and ZYNTHIO (parent company, incorporating in New Zealand).
 
 The founder, Corey McIvor, built the entire stack — the AI integrations, the Next.js frontends, the brand architecture, the music, and the legal filings. He is both the engineer and the artist. Every track released under DJ Zynrose is made using the same tools Zynthio builds for everyone.
 
 ### The Full Version (300 words)
 
-The post-AI creative economy has a structural problem: the tools are getting better, but the infrastructure around them is getting worse. Independent creators can now produce studio-quality music in minutes — but the platforms capturing that value give nothing back. Education hasn't caught up. Legal protection remains inaccessible. AI trading is opaque and gatekept. The full pipeline from creation to ownership is broken.
+The post-AI creative economy has a structural problem: the tools are getting better, but the infrastructure around them is getting worse. Independent creators can produce studio-quality music in minutes — but the platforms capturing that value give nothing back. Education hasn't caught up. Legal protection remains inaccessible. AI trading is opaque and gatekept. The full pipeline from creation to ownership is broken.
 
 Zynthio is the answer to that structural problem. Founded by Corey McIvor — a New Zealand/Australian dual citizen, full-stack developer, AI engineer, and working music producer — Zynthio is a vertically integrated creative-technology ecosystem built from the ground up.
 
-The architecture is deliberate. SongPal is the flagship AI music production platform, with a trademark filed at IPONZ (#1318588). CoreeyAI is the intelligence layer — not a wrapper around one API, but a purpose-built orchestration system routing tasks across Claude, Grok, Perplexity, and Suno. MOSOKO teaches independent creators how to use the full stack. KERVALON handles IP protection. CoreIntent is the engineering arm, also operating gTrade — an autonomous, risk-managed trading bot that self-funds development using a competition-based model: open architecture, verifiable risk parameters, no subscription black boxes. And DJ Zynrose is Corey's artist persona: the living proof that the stack works.
+The architecture is deliberate. SongPal is the flagship AI music production platform, with a trademark filed at IPONZ (#1318588). CoreeyAI is the intelligence layer — not a wrapper around one API, but a purpose-built orchestration system routing tasks across Claude, Grok, Perplexity, and Suno. MOSOKO teaches independent creators the full stack. KERVALON handles IP protection. CoreIntent is the engineering arm, also operating gTrade — an autonomous, risk-managed trading bot that self-funds development using a competition-based model: open architecture, verifiable risk parameters, no subscription black boxes. DJ Zynrose is Corey's artist persona: the living proof that the stack works.
 
-The company is incorporating as ZYNTHIO LIMITED in New Zealand in May 2026. The infrastructure is live — Next.js, Python 3.11, Docker, multi-model AI integrations, and a public documentation repository on GitHub. The team is the founder. The burn rate is under NZD $500/month. The ambition is global.
+ZYNTHIO LIMITED is incorporating in New Zealand in May 2026. The infrastructure is live — Next.js, Python 3.11, Docker, multi-model AI integrations, and a public documentation repository on GitHub. The team is the founder. The burn rate is under NZD $500/month. The ambition is global.
 
-Zynthio is targeting a ~$21B+ combined addressable market. The seed raise is NZD $150–250K. The moat: no competitor combines AI production, education, IP infrastructure, autonomous trading, and an artist persona under one sovereign architecture.
+Zynthio targets a ~$21B+ combined addressable market across music production, AI music, online education, and AI-assisted retail trading. The seed raise is NZD $150–250K. The moat: no competitor combines AI production, education, IP infrastructure, autonomous trading, and an artist persona under one sovereign architecture.
 
 No filler. All signal.
 
@@ -67,7 +67,7 @@ MOSOKO teaches independent creators the full stack. KERVALON protects every asse
 
 ### On the vision:
 
-> "We're not pitching a feature. We're pitching a new creative infrastructure for the post-AI world."
+> "We're not pitching a feature. We're pitching new creative infrastructure for the post-AI world."
 
 > "Zynthio is not a product. It is a stack. Build, think, create, teach, protect, scale — all under one roof."
 
@@ -185,7 +185,7 @@ MOSOKO teaches independent creators the full stack. KERVALON protects every asse
 | Brands | 7 interconnected brands |
 | AI models | Claude, Grok, Perplexity, Suno |
 | Tech stack | Next.js, Python 3.11, Docker, sovereign VPS |
-| Combined TAM | ~$21.4B+ |
+| Combined TAM | ~$21.5B+ |
 | Funding stage | Pre-seed (bootstrapped + gTrade self-funding) |
 | Seed target | NZD $150,000–250,000 |
 | Monthly burn | ~NZD $280–480 |
@@ -197,7 +197,7 @@ MOSOKO teaches independent creators the full stack. KERVALON protects every asse
 
 ## Logos & Visual Assets
 
-*Status: Pending design. Update this section when assets are created.*
+*Status: Pending design. Update when assets are created.*
 
 | Asset | Status | Location |
 |-------|--------|----------|
@@ -221,15 +221,15 @@ Domain: [zynthio.ai](https://zynthio.ai)
 
 ## Usage Guidelines
 
-1. Use "Zynthio" (capital Z) in all editorial contexts — not "ZYNTHIO" unless in a legal or branding context
+1. Use "Zynthio" (capital Z) in editorial contexts — "ZYNTHIO" only in legal or branding contexts
 2. Use "SongPal" as two words with capitals — not "Songpal" or "Song Pal"
 3. Use "CoreIntent" as one word with capital C and I — not "Core Intent" or "Coreintent"
-4. Include TM symbol (SongPal™) in first mention within any document
+4. Include TM symbol (SongPal™) on first mention within any document
 5. DJ Zynrose is the artist name — refer to the person as "Corey McIvor" in non-artist contexts
-6. Signal Gold (#C9A84C) should be used sparingly — it is an accent, not a fill colour
+6. Signal Gold (#C9A84C) is an accent — use sparingly, not as a fill colour
 7. All brand assets are copyright ZYNTHIO / Corey McIvor unless otherwise stated
 8. Codebase is MIT-licensed — brand assets are not
 
 ---
 
-*Last updated: 2026-05-09 (Session 29) | Maintained by: Corey McIvor / COREINTENT*
+*Last updated: 2026-05-11 | Maintained by: Corey McIvor / COREINTENT*


### PR DESCRIPTION
## Summary

- Rewrote all five competition-facing documents with tighter, competition-grade language
- Updated dates to 2026-05-11 across all materials
- Added 5 new competition targets (Blackbird Giants, Abbey Road Red, Techstars Music, Web Summit PITCH, Slush 100) — tracker now at 25+
- Sharpened problem statement, executive summary, and competitive positioning throughout
- Tightened demo script pacing and adaptation notes

## Files changed

- `COMPETITION_PORTFOLIO.md` — full rewrite with crisper sections
- `PITCH_DECK_OUTLINE.md` — polished 10-slide structure
- `DEMO_SCRIPT.md` — tighter 3-minute walkthrough
- `PRESS_KIT.md` — refreshed brand story, bios, quotes
- `AWARDS_TRACKER.md` — expanded from 21 to 25+ targets

## Test plan

- [ ] Verify all internal doc links resolve correctly
- [ ] Confirm no placeholder emails or missing data
- [ ] Review executive summary is exactly 50 words
- [ ] Spot-check competition entries for accurate URLs and descriptions

https://claude.ai/code/session_01HLw4dZrgEMB1BcwdDKAceT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLw4dZrgEMB1BcwdDKAceT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates (copy/structure) plus expanded competition tracker entries; no code paths or runtime behavior affected.
> 
> **Overview**
> Refreshes the competition-facing docs (`COMPETITION_PORTFOLIO.md`, `PITCH_DECK_OUTLINE.md`, `DEMO_SCRIPT.md`, `PRESS_KIT.md`) with tighter positioning, clearer structure, and updated figures/wording for submissions.
> 
> Updates `AWARDS_TRACKER.md` to reflect 2026-05-11 status, restructures prerequisite/checklist sections, and expands the dashboard and timeline to include additional competition targets (now ~25+).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ecc83e75e3f4c0faa6ab42bac0dea143f7db041. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->